### PR TITLE
[refactor] #34 Transaction layer 변경 및 Post updatedAt, lastEditedAt 구분 완료

### DIFF
--- a/src/main/java/ussum/homepage/application/comment/service/CommentService.java
+++ b/src/main/java/ussum/homepage/application/comment/service/CommentService.java
@@ -33,6 +33,7 @@ public class CommentService {
         Page<PostComment> commentList = postCommentReader.getPostCommentList(setPageable(page, take), postId);
         return PostCommentListResponse.of(commentList, commentList.getTotalElements(), postCommentFormatter::format, type);
     }
+    @Transactional
     public PostCommentResponse createComment(Long userId, String boardCode, Long postId, PostCommentCreateRequest postCommentCreateRequest){
         PostComment postComment = postCommentAppender.createPostComment(postCommentCreateRequest.toDomain(userId,postId));
         return postCommentFormatter.format(postComment.getPostId(), postComment.getUserId(), null);

--- a/src/main/java/ussum/homepage/application/comment/service/dto/request/PostCommentUpdateRequest.java
+++ b/src/main/java/ussum/homepage/application/comment/service/dto/request/PostCommentUpdateRequest.java
@@ -2,6 +2,8 @@ package ussum.homepage.application.comment.service.dto.request;
 
 import ussum.homepage.domain.comment.PostComment;
 
+import java.time.LocalDateTime;
+
 public record PostCommentUpdateRequest(
         String content
 ) {
@@ -11,7 +13,8 @@ public record PostCommentUpdateRequest(
                 content,
                 postId,
                 userId,
-                null
+                String.valueOf(LocalDateTime.now())
         );
     }
+
 }

--- a/src/main/java/ussum/homepage/application/post/service/dto/request/PostCreateRequest.java
+++ b/src/main/java/ussum/homepage/application/post/service/dto/request/PostCreateRequest.java
@@ -26,7 +26,6 @@ public record PostCreateRequest(
                 null,
                 null,
                 null,
-                null,
                 user.getId(), //이건 채워넣어야 함, user쪽 개발되면
                 board.getId(),
                 category.getId()

--- a/src/main/java/ussum/homepage/application/post/service/dto/request/PostUpdateRequest.java
+++ b/src/main/java/ussum/homepage/application/post/service/dto/request/PostUpdateRequest.java
@@ -20,9 +20,8 @@ public record PostUpdateRequest(
                 post.getViewCount(),
                 thumbnailImage,
                 LocalDateTime.parse(post.getCreatedAt()),
-                null,
+                LocalDateTime.parse(post.getUpdatedAt()),
                 LocalDateTime.now(),
-                null,
                 post.getUserId(),
                 board.getId(),
                 category.getId()

--- a/src/main/java/ussum/homepage/application/reaction/controller/PostCommentReactionController.java
+++ b/src/main/java/ussum/homepage/application/reaction/controller/PostCommentReactionController.java
@@ -16,7 +16,7 @@ public class PostCommentReactionController {
     @PostMapping("/boards/posts/comments/{commentId}/reactions")
     public ApiResponse<Void> createPostCommentReaction(@PathVariable(name = "commentId") Long commentId,
                                                                               @RequestBody PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
-        PostCommentReactionResponse commentReaction = postCommentReactionService.createCommentReaction(commentId, postCommentReactionCreateRequest);
+        PostCommentReactionResponse commentReaction = postCommentReactionService.createPostCommentReaction(commentId, postCommentReactionCreateRequest);
 //        return ApiResponse.onSuccess(commentReaction);
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/ussum/homepage/application/reaction/service/PostCommentReactionService.java
+++ b/src/main/java/ussum/homepage/application/reaction/service/PostCommentReactionService.java
@@ -41,9 +41,7 @@ public class PostCommentReactionService {
     @Transactional
     public void deletePostCommentReaction(Long commentId, PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
         Long userId = 1L; //여기에 userId 추출하는 거 추가
-//        PostCommentReaction postCommentReaction = postCommentReactionReader.getPostCommentReactionWithCommentIdAndUserId(commentId, userId, postCommentReactionCreateRequest.reaction());
-        postCommentReactionModifier.deletePostCommentReaction(commentId, userId, postCommentReactionCreateRequest.reaction());
-//        postCommentReactionModifier.deletePostCommentReaction(postCommentReaction.getPostCommentId(), postCommentReaction.getUserId(),
-//                postCommentReaction.getReactionType());
+        PostCommentReaction postCommentReaction = postCommentReactionReader.getPostCommentReactionWithCommentIdAndUserId(commentId, userId, postCommentReactionCreateRequest.reaction());
+        postCommentReactionModifier.deletePostCommentReaction(postCommentReaction);
     }
 }

--- a/src/main/java/ussum/homepage/application/reaction/service/PostCommentReactionService.java
+++ b/src/main/java/ussum/homepage/application/reaction/service/PostCommentReactionService.java
@@ -25,7 +25,7 @@ public class PostCommentReactionService {
     private final PostCommentReactionFormatter postCommentReactionFormatter;
     private final PostCommentReactionReader postCommentReactionReader;
 
-    public PostCommentReactionResponse createCommentReaction(Long commentId, PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
+    public PostCommentReactionResponse createPostCommentReaction(Long commentId, PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
         PostComment postComment = postCommentReader.getPostComment(commentId);
         Long userId = 1L; //여기에 userId 추출하는 거 추가
         postCommentReactionManager.validatePostCommentReactionByCommentIdAndUserId(commentId, userId, postCommentReactionCreateRequest.reaction()); //해당 유저가 해당 댓글에 좋아요를 이미 눌렀는지 안눌렀는지 검증

--- a/src/main/java/ussum/homepage/application/reaction/service/PostCommentReactionService.java
+++ b/src/main/java/ussum/homepage/application/reaction/service/PostCommentReactionService.java
@@ -16,7 +16,7 @@ import ussum.homepage.domain.reaction.service.PostCommentReactionReader;
 
 @Service
 @RequiredArgsConstructor
-//@Transactional(readOnly = true)
+@Transactional(readOnly = true)
 public class PostCommentReactionService {
     private final PostCommentReader postCommentReader;
     private final PostCommentReactionAppender postCommentReactionAppender;
@@ -25,6 +25,7 @@ public class PostCommentReactionService {
     private final PostCommentReactionFormatter postCommentReactionFormatter;
     private final PostCommentReactionReader postCommentReactionReader;
 
+    @Transactional
     public PostCommentReactionResponse createPostCommentReaction(Long commentId, PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
         PostComment postComment = postCommentReader.getPostComment(commentId);
         Long userId = 1L; //여기에 userId 추출하는 거 추가

--- a/src/main/java/ussum/homepage/application/reaction/service/PostReactionService.java
+++ b/src/main/java/ussum/homepage/application/reaction/service/PostReactionService.java
@@ -10,15 +10,16 @@ import ussum.homepage.domain.postlike.service.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PostReactionService {
     private final PostReactionAppender postReactionAppender;
     private final PostReactionModifier postReactionModifier;
     private final PostReactionManager postReactionManager;
-    private final PostReactionReader postReactionReader;
     private final PostReactionFormatter postReactionFormatter;
 
 
     //일단 반환 값 void말고 responseDto로 해놓고 나중에 없애도 될 것 같음.
+    @Transactional
     public PostReactionResponse createPostReaction(Long postId, PostReactionCreateRequest postReactionCreateRequest) {
         Long userId = 1L; //여기에 userId 추출하는 거 추가
         postReactionManager.validatePostReactionByCommentIdAndUserId(postId, userId, postReactionCreateRequest.reaction());

--- a/src/main/java/ussum/homepage/application/reaction/service/PostReactionService.java
+++ b/src/main/java/ussum/homepage/application/reaction/service/PostReactionService.java
@@ -24,6 +24,7 @@ public class PostReactionService {
     private final PostReactionAppender postReactionAppender;
     private final PostReactionModifier postReactionModifier;
     private final PostReactionManager postReactionManager;
+    private final PostReactionReader postReactionReader;
     private final PostReactionFormatter postReactionFormatter;
 
     @Transactional

--- a/src/main/java/ussum/homepage/domain/comment/service/PostCommentAppender.java
+++ b/src/main/java/ussum/homepage/domain/comment/service/PostCommentAppender.java
@@ -10,7 +10,7 @@ import ussum.homepage.domain.comment.PostCommentRepository;
 @RequiredArgsConstructor
 public class PostCommentAppender {
     private final PostCommentRepository postCommentRepository;
-    @Transactional
+
     public PostComment createPostComment(PostComment postComment){
         return postCommentRepository.save(postComment);
     }

--- a/src/main/java/ussum/homepage/domain/post/Post.java
+++ b/src/main/java/ussum/homepage/domain/post/Post.java
@@ -25,7 +25,7 @@ public class Post {
     private String createdAt;
     private String updatedAt;
     private String lastEditedAt;
-    private String deletedAt;
+//    private String deletedAt;
     private Long userId;
     private Long boardId;
     private Long categoryId;
@@ -38,12 +38,12 @@ public class Post {
                           LocalDateTime createdAt,
                           LocalDateTime updatedAt,
                           LocalDateTime lastEditedAt,
-                          LocalDateTime deletedAt,
+//                          LocalDateTime deletedAt,
                           Long userId,
                           Long boardId,
                           Long categoryId) {
         return new Post(id, title, content, viewCount, thumbnailImage, String.valueOf(createdAt),
-                String.valueOf(updatedAt), String.valueOf(lastEditedAt), String.valueOf(deletedAt),
+                String.valueOf(updatedAt), String.valueOf(lastEditedAt),
                 userId, boardId, categoryId);
     }
 }

--- a/src/main/java/ussum/homepage/domain/postlike/service/PostReactionAppender.java
+++ b/src/main/java/ussum/homepage/domain/postlike/service/PostReactionAppender.java
@@ -12,7 +12,6 @@ import ussum.homepage.domain.postlike.PostReactionRepository;
 public class PostReactionAppender {
     private final PostReactionRepository postReactionRepository;
 
-    @Transactional
     public PostReaction createPostReaction(PostReaction postReaction) {
         return postReactionRepository.save(postReaction);
     }

--- a/src/main/java/ussum/homepage/domain/reaction/service/PostCommentReactionAppender.java
+++ b/src/main/java/ussum/homepage/domain/reaction/service/PostCommentReactionAppender.java
@@ -11,7 +11,6 @@ import ussum.homepage.domain.reaction.PostCommentReactionRepository;
 public class PostCommentReactionAppender {
     private final PostCommentReactionRepository postCommentReactionRepository;
 
-    @Transactional
     public PostCommentReaction createPostCommentReaction(PostCommentReaction postCommentReaction) {
         return postCommentReactionRepository.save(postCommentReaction);
     }

--- a/src/main/java/ussum/homepage/domain/reaction/service/PostCommentReactionModifier.java
+++ b/src/main/java/ussum/homepage/domain/reaction/service/PostCommentReactionModifier.java
@@ -2,17 +2,15 @@ package ussum.homepage.domain.reaction.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import ussum.homepage.domain.reaction.PostCommentReaction;
 import ussum.homepage.domain.reaction.PostCommentReactionRepository;
 
 @Service
 @RequiredArgsConstructor
 public class PostCommentReactionModifier {
     private final PostCommentReactionRepository postCommentReactionRepository;
-    private final PostCommentReactionReader postCommentReactionReader;
 
-    public void deletePostCommentReaction(Long commentId, Long userId, String reaction) {
-        postCommentReactionRepository.delete(
-                postCommentReactionReader.getPostCommentReactionWithCommentIdAndUserId(commentId, userId, reaction)
-        );
+    public void deletePostCommentReaction(PostCommentReaction postCommentReaction) {
+        postCommentReactionRepository.delete(postCommentReaction);
     }
 }

--- a/src/main/java/ussum/homepage/infra/jpa/comment/PostCommentMapper.java
+++ b/src/main/java/ussum/homepage/infra/jpa/comment/PostCommentMapper.java
@@ -20,12 +20,16 @@ public class PostCommentMapper {
                 );
     }
     public PostCommentEntity toEntity(PostComment postComment){
+        LocalDateTime lastEditedAt = null;
+        if (postComment.getLastEditedAt() != null) {
+            lastEditedAt = LocalDateTime.parse(postComment.getLastEditedAt());
+        }
         return PostCommentEntity.of(
                 postComment.getId(),
                 postComment.getContent(),
                 PostEntity.from(postComment.getPostId()),
                 UserEntity.from(postComment.getUserId()),
-                LocalDateTime.parse(postComment.getLastEditedAt())
+                lastEditedAt
         );
     }
 }

--- a/src/main/java/ussum/homepage/infra/jpa/comment/PostCommentRepositoryImpl.java
+++ b/src/main/java/ussum/homepage/infra/jpa/comment/PostCommentRepositoryImpl.java
@@ -1,6 +1,7 @@
 package ussum.homepage.infra.jpa.comment;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -8,6 +9,9 @@ import ussum.homepage.domain.comment.PostComment;
 import ussum.homepage.domain.comment.PostCommentRepository;
 import ussum.homepage.global.error.exception.GeneralException;
 import ussum.homepage.infra.jpa.comment.repository.PostCommentJpaRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static ussum.homepage.global.error.status.ErrorStatus.POST_COMMENT_NOT_FOUND;
 

--- a/src/main/java/ussum/homepage/infra/jpa/comment/entity/PostCommentEntity.java
+++ b/src/main/java/ussum/homepage/infra/jpa/comment/entity/PostCommentEntity.java
@@ -1,7 +1,9 @@
 package ussum.homepage.infra.jpa.comment.entity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
 import ussum.homepage.domain.comment.PostComment;
+import ussum.homepage.infra.jpa.BaseEntity;
 import ussum.homepage.infra.jpa.post.entity.PostEntity;
 import ussum.homepage.infra.jpa.user.entity.UserEntity;
 
@@ -24,6 +26,8 @@ public class PostCommentEntity {
     private UserEntity userEntity;
     @Enumerated(EnumType.STRING)
     private CommentType type;
+
+    @LastModifiedDate
     private LocalDateTime lastEditedAt;
 
     public PostCommentEntity(Long id, String content, PostEntity postEntity, UserEntity userEntity, LocalDateTime lastEditedAt) {

--- a/src/main/java/ussum/homepage/infra/jpa/post/PostMapper.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/PostMapper.java
@@ -25,7 +25,6 @@ public class PostMapper {
                 postEntity.getCreatedAt(),
                 postEntity.getUpdatedAt(),
                 postEntity.getLastEditedAt(),
-                postEntity.getDeletedAt(),
                 postEntity.getUserEntity().getId(),
                 postEntity.getBoardEntity().getId(),
                 postEntity.getCategoryEntity().getId()
@@ -33,19 +32,15 @@ public class PostMapper {
     }
 
     public PostEntity toEntity(Post post, UserEntity user, BoardEntity board, CategoryEntity category) {
-//        PostEntity from = PostEntity.from(post.getId());
-//        LocalDateTime lastEditedAt = post.getLastEditedAt() != null ? LocalDateTime.parse(post.getLastEditedAt()) : null;
-//        LocalDateTime deletedAt = post.getDeletedAt() != null ? LocalDateTime.parse(post.getDeletedAt()) : null;
         LocalDateTime lastEditedAt = null;
-        LocalDateTime deletedAt = null;
+//        LocalDateTime deletedAt = null;
 
         if (post.getLastEditedAt() != null && !"null".equals(post.getLastEditedAt())) {
             lastEditedAt = LocalDateTime.parse(post.getLastEditedAt());
         }
-
-        if (post.getDeletedAt() != null && !"null".equals(post.getDeletedAt())) {
-            deletedAt = LocalDateTime.parse(post.getDeletedAt());
-        }
+//        if (post.getDeletedAt() != null && !"null".equals(post.getDeletedAt())) {
+//            deletedAt = LocalDateTime.parse(post.getDeletedAt());
+//        }
 
         return PostEntity.of(
                 post.getId(),
@@ -54,7 +49,6 @@ public class PostMapper {
                 post.getViewCount(),
                 post.getThumbnailImage(),
                 lastEditedAt,
-                deletedAt,
                 user,
                 board,
                 category

--- a/src/main/java/ussum/homepage/infra/jpa/post/PostRepositoryImpl.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/PostRepositoryImpl.java
@@ -19,11 +19,13 @@ import ussum.homepage.infra.jpa.user.entity.MajorCode;
 import ussum.homepage.infra.jpa.user.entity.UserEntity;
 import ussum.homepage.infra.jpa.user.repository.UserJpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static ussum.homepage.global.error.status.ErrorStatus.*;
 import static ussum.homepage.infra.jpa.post.entity.PostEntity.increaseViewCount;
+import static ussum.homepage.infra.jpa.post.entity.PostEntity.updateLastEditedAt;
 
 @Repository
 @RequiredArgsConstructor
@@ -51,6 +53,7 @@ public class PostRepositoryImpl implements PostRepository {
     public Optional<Post> findByBoardIdAndIdForEditAndDelete(Long boardId, Long postId) {
         BoardEntity boardEntity = boardJpaRepository.findById(boardId).orElseThrow(() -> new GeneralException(BOARD_NOT_FOUND));
         Optional<PostEntity> post = postJpaRepository.findByBoardEntityAndId(boardEntity, postId);
+        updateLastEditedAt(post.get());
         return post.map(postMapper::toDomain);
     }
 

--- a/src/main/java/ussum/homepage/infra/jpa/post/entity/PostEntity.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/entity/PostEntity.java
@@ -1,14 +1,11 @@
 package ussum.homepage.infra.jpa.post.entity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-import org.springframework.cglib.core.Local;
+import org.springframework.data.annotation.LastModifiedDate;
 import ussum.homepage.infra.jpa.BaseEntity;
 import ussum.homepage.infra.jpa.user.entity.UserEntity;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 @Table(name = "post")
@@ -23,8 +20,9 @@ public class PostEntity extends BaseEntity {
     private String content;
     private Integer viewCount;
     private String thumbnailImage;
+
     private LocalDateTime lastEditedAt;
-    private LocalDateTime deletedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity userEntity;
@@ -36,18 +34,19 @@ public class PostEntity extends BaseEntity {
     private CategoryEntity categoryEntity;
 
     public static PostEntity from(Long id){
-        return new PostEntity(id,null,null,null,null,null,null,null,null,null);
+        return new PostEntity(id,null,null,null,null,null,null,null,null);
     }
 
     public static PostEntity of(Long id, String title, String content, Integer viewCount, String thumbnailImage,
-                                LocalDateTime lastEditedAt, LocalDateTime deletedAt, UserEntity user, BoardEntity board, CategoryEntity category) {
-        return new PostEntity(id, title, content, viewCount, thumbnailImage, lastEditedAt, deletedAt, user, board, category);
+                                LocalDateTime lastEditedAt, UserEntity user, BoardEntity board, CategoryEntity category) {
+        return new PostEntity(id, title, content, viewCount, thumbnailImage, lastEditedAt, user, board, category);
     }
 
     public static void increaseViewCount(PostEntity post) {
         post.viewCount += 1;
-        LocalDateTime updatedAt = post.getUpdatedAt();
-        updatedAt = LocalDateTime.now();
     }
 
+    public static void updateLastEditedAt(PostEntity post) {
+        post.lastEditedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/ussum/homepage/infra/jpa/post/repository/PostJpaRepository.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/repository/PostJpaRepository.java
@@ -32,7 +32,6 @@ public interface PostJpaRepository extends JpaRepository<PostEntity,Long> {
                     WHERE pe.boardEntity = :board 
                     AND (:q IS NULL OR pe.title LIKE %:q% OR pe.content LIKE %:q%)
                     AND (:categoryCode IS NULL OR pe.categoryEntity.majorCode = :categoryCode)
-                    AND pe.deletedAt IS NULL
                     ORDER BY pe.id DESC
             """)
     Page<PostEntity> findBySearchCriteria(Pageable pageable,


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- PostCommentReactionModifier에 Reader 의존성 삭제 후, deletePostCommentReaction 메소드에 delete 메소드는 삭제 역할만 담당함
- @Transactinoal의 layer를 service layer로 이동 
- PostEntity deletedAt 필드 삭제 및 updatedAt, lastEditedAt 구분 완료
  - 게시글 내용 및 제목 변경 시 updatedAt, lastEditedAt 모두 변경 -> 게시글 조회 시 viewCount 증가할 때는
 updatedAt만 변경됨
- PostComment의 lastEditedAt 필드 값 NPE 이슈 해결
---

### ✏️ 관련 이슈(선택 사항)
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #34 
- Ref : #36 


---

### 코드 리뷰 받고 싶은 부분
어제 merge되었던 PostReaction 수정사항과 크게 겹치지 않아(PostCommentReaction 위주로 작업했기에) 우선 해당 pr merge 후에
PostCommentReaction api 1개의 api로 합치는 과정 진행해도 문제 없지 않을까요

---




