### PR TITLE
[refactor] #38 searchBoardPost api 검색 로직 수정 및 postcommentreaction toggle 형식으로 리팩토링 

### DIFF
--- a/src/main/java/ussum/homepage/application/comment/controller/CommentController.java
+++ b/src/main/java/ussum/homepage/application/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package ussum.homepage.application.comment.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ussum.homepage.application.comment.service.CommentService;
 import ussum.homepage.application.comment.service.dto.PostCommentListResponse;
@@ -16,34 +17,34 @@ import ussum.homepage.global.ApiResponse;
 public class CommentController {
     private final CommentService commentService;
     @GetMapping("/boards/{boardCode}/posts/{postId}/comments")
-    public ApiResponse<PostCommentListResponse> getPostCommentList(@PathVariable(name = "boardCode") String boardCode,
-                                                             @PathVariable(name = "postId") Long postId,
-                                                             @RequestParam(name = "page") int page,
-                                                             @RequestParam(name = "take") int take,
-                                                             @RequestParam(required = false, name = "type") String type) {
+    public ResponseEntity<ApiResponse<?>> getPostCommentList(@PathVariable(name = "boardCode") String boardCode,
+                                                                                  @PathVariable(name = "postId") Long postId,
+                                                                                  @RequestParam(name = "page") int page,
+                                                                                  @RequestParam(name = "take") int take,
+                                                                                  @RequestParam(required = false, name = "type") String type) {
         PostCommentListResponse comments = commentService.getCommentList(boardCode, postId, page, take, type);
-        return ApiResponse.onSuccess(comments);
+        return ApiResponse.success(comments);
     }
     @PostMapping("/boards/{boardCode}/posts/{postId}/comments")
-    public ApiResponse<PostCommentResponse> createPostComment(@PathVariable(name = "boardCode") String boardCode,
-                                                              @PathVariable(name = "postId") Long postId,
-                                                              @RequestBody PostCommentCreateRequest postCommentCreateRequest) {
+    public ResponseEntity<ApiResponse<?>> createPostComment(@PathVariable(name = "boardCode") String boardCode,
+                                                            @PathVariable(name = "postId") Long postId,
+                                                            @RequestBody PostCommentCreateRequest postCommentCreateRequest) {
         PostCommentResponse comment = commentService.createComment(null, boardCode, postId, postCommentCreateRequest);
-        return ApiResponse.onSuccess(comment);
+        return ApiResponse.success(comment);
     }
     @PatchMapping("/boards/{boardCode}/posts/{postId}/comments/{commentId}")
-    public ApiResponse<PostCommentResponse> editPostComment(@PathVariable(name = "boardCode") String boardCode,
-                                                            @PathVariable(name = "postId") Long postId,
-                                                            @PathVariable(name = "commentId") Long commentId,
-                                                            @RequestBody PostCommentUpdateRequest postCommentUpdateRequest) {
+    public ResponseEntity<ApiResponse<?>> editPostComment(@PathVariable(name = "boardCode") String boardCode,
+                                                          @PathVariable(name = "postId") Long postId,
+                                                          @PathVariable(name = "commentId") Long commentId,
+                                                          @RequestBody PostCommentUpdateRequest postCommentUpdateRequest) {
         PostCommentResponse comment = commentService.editComment(null, postId, commentId, postCommentUpdateRequest);
-        return ApiResponse.onSuccess(comment);
+        return ApiResponse.success(comment);
     }
     @DeleteMapping("/boards/{boardCode}/posts/{postId}/comments/{commentId}")
-    public ApiResponse<PostCommentResponse> deletePostComment(@PathVariable(name = "boardCode") String boardCode,
+    public ResponseEntity<ApiResponse<?>> deletePostComment(@PathVariable(name = "boardCode") String boardCode,
                                                             @PathVariable(name = "postId") Long postId,
                                                             @PathVariable(name = "commentId") Long commentId) {
         commentService.deleteComment(commentId);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.success(null);
     }
 }

--- a/src/main/java/ussum/homepage/application/post/controller/PostController.java
+++ b/src/main/java/ussum/homepage/application/post/controller/PostController.java
@@ -3,6 +3,7 @@ package ussum.homepage.application.post.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ussum.homepage.application.post.service.PostService;
 import ussum.homepage.application.post.service.dto.request.PostCreateRequest;
@@ -19,47 +20,54 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping("/{boardCode}/posts")
-    public ApiResponse<PostListResponse> getBoardPostsList(@RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "take") int take,
+    public ResponseEntity<ApiResponse<?>> getBoardPostsList(@RequestParam(value = "page", defaultValue = "0") int page,
+                                                            @RequestParam(value = "take") int take,
                                                            @PathVariable(name = "boardCode") String boardCode) {
 
         PostListResponse postList = postService.getPostList(PageRequest.of(page, take, Sort.by("id").descending()), boardCode);
-        return ApiResponse.onSuccess(postList);
+        return ApiResponse.success(postList);
     }
 
     @GetMapping("/{boardCode}/posts/{postId}")
-    public ApiResponse<PostResponse> getBoardPost(@PathVariable(name = "boardCode") String boardCode,
-                                                  @PathVariable(name = "postId") Long postId) {
+    public ResponseEntity<ApiResponse<?>> getBoardPost(@PathVariable(name = "boardCode") String boardCode,
+                                                       @PathVariable(name = "postId") Long postId) {
 
-        return ApiResponse.onSuccess(postService.getPost(boardCode, postId));
+        PostResponse post = postService.getPost(boardCode, postId);
+        return ApiResponse.success(post);
     }
 
     @PostMapping("/{boardCode}/posts")
-    public ApiResponse<?> createBoardPost(@UserId Long userId, @PathVariable(name = "boardCode") String boardCode,
-                                          @RequestBody PostCreateRequest postCreateRequest) {
+    public ResponseEntity<ApiResponse<?>> createBoardPost(@UserId Long userId,
+                                                          @PathVariable(name = "boardCode") String boardCode,
+                                                          @RequestBody PostCreateRequest postCreateRequest) {
         postService.createPost(userId, boardCode,postCreateRequest);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.success(null);
     }
 
     @PatchMapping("/{boardCode}/posts/{postId}")
-    public ApiResponse<PostResponse> editBoardPost(@PathVariable(name = "boardCode") String boardCode, @PathVariable(name = "postId") Long postId,
-                                                   @RequestBody PostUpdateRequest postUpdateRequest) {
+    public ResponseEntity<ApiResponse<?>> editBoardPost(@PathVariable(name = "boardCode") String boardCode,
+                                                        @PathVariable(name = "postId") Long postId,
+                                                        @RequestBody PostUpdateRequest postUpdateRequest) {
         PostResponse post = postService.editPost(boardCode,postId, postUpdateRequest);
-        return ApiResponse.onSuccess(post);
+        return ApiResponse.success(post);
     }
 
     @DeleteMapping("/{boardCode}/posts/{postId}")
-    public ApiResponse<?> deleteBoardPost(@PathVariable(name = "boardCode") String boardCode, @PathVariable(name = "postId") Long postId) {
+    public ResponseEntity<ApiResponse<?>> deleteBoardPost(@PathVariable(name = "boardCode") String boardCode,
+                                                          @PathVariable(name = "postId") Long postId) {
         postService.deletePost(boardCode, postId);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.success(null);
     }
 
     @GetMapping("/{boardCode}/posts/search")
-    public ApiResponse<PostListResponse> searchBoardPost(@RequestParam(value = "q") String q, @RequestParam(value = "categorycode") String categoryCode,
-                                                    @RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "take") int take,
-                                                    @PathVariable String boardCode) {
-        return ApiResponse.onSuccess(postService.searchPost(
-                PageRequest.of(page, take, Sort.by("id").descending()), boardCode, q, categoryCode)
-        );
+    public ResponseEntity<ApiResponse<?>> searchBoardPost(@RequestParam(value = "q") String q,
+                                                          @RequestParam(value = "categoryCode") String categoryCode,
+                                                          @RequestParam(value = "page", defaultValue = "0") int page,
+                                                          @RequestParam(value = "take") int take,
+                                                          @PathVariable String boardCode) {
+
+        PostListResponse postList = postService.searchPost(PageRequest.of(page, take, Sort.by("id").descending()), boardCode, q, categoryCode);
+        return ApiResponse.success(postList);
     }
 
 

--- a/src/main/java/ussum/homepage/application/post/service/PostService.java
+++ b/src/main/java/ussum/homepage/application/post/service/PostService.java
@@ -70,7 +70,7 @@ public class PostService {
 
     public PostListResponse searchPost(Pageable pageable, String boardCode, String q, String categoryCode) {
         Page<Post> searchPost = postReader.getPostListBySearch(pageable, boardCode, q, categoryCode);
-        return PostListResponse.of(searchPost.getContent(), (int) searchPost.getTotalElements(),
+        return PostListResponse.of(searchPost.getContent(), /*(int) searchPost.getTotalElements()*/ searchPost.getContent().size(),
                 postFormatter::format);
     }
 }

--- a/src/main/java/ussum/homepage/application/reaction/controller/PostCommentReactionController.java
+++ b/src/main/java/ussum/homepage/application/reaction/controller/PostCommentReactionController.java
@@ -29,24 +29,24 @@ public class PostCommentReactionController {
             """)
     @PostMapping("/toggle/posts/{commentId}")
     public ResponseEntity<ApiResponse<?>> togglePostCommentReaction(@UserId Long userId,
-                                                             @PathVariable(name = "commentId") Long commentId,
-                                                             @RequestBody CreatePostCommentReactionReq createPostCommentReactionReq) {
+                                                                    @PathVariable(name = "commentId") Long commentId,
+                                                                    @RequestBody CreatePostCommentReactionReq createPostCommentReactionReq) {
         postCommentReactionService.postCommentReactionToggle(userId, commentId, createPostCommentReactionReq);
-        return ApiResponse.success(null);
+        return ApiResponse.success("배현서 박정우 11번가 입사를 축하드립니다.");
     }
 
     @Operation(summary = "게시물 댓글 반응 생성 api", description = """
             게시물 댓글 반응을 등록하기 위한 api입니다.
             
-            요청 json으로 like 또는 unlike를 받습니다.
+            요청 json으로 like 또는 unlike를 
+            받습니다.
             
             """)
     @PostMapping("/boards/posts/comments/{commentId}/reactions")
-    public ApiResponse<Void> createPostCommentReaction(@PathVariable(name = "commentId") Long commentId,
-                                                                              @RequestBody PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
-        PostCommentReactionResponse commentReaction = postCommentReactionService.createPostCommentReaction(commentId, postCommentReactionCreateRequest);
-//        return ApiResponse.onSuccess(commentReaction);
-        return ApiResponse.onSuccess(null);
+    public ResponseEntity<ApiResponse<?>> createPostCommentReaction(@PathVariable(name = "commentId") Long commentId,
+                                                                    @RequestBody PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
+        postCommentReactionService.createPostCommentReaction(commentId, postCommentReactionCreateRequest);
+        return ApiResponse.success(null);
     }
 
     @Operation(summary = "게시물 댓글 반응 삭제 api", description = """
@@ -56,9 +56,9 @@ public class PostCommentReactionController {
             
             """)
     @DeleteMapping("/boards/posts/comments/{commentId}/reactions")
-    public ApiResponse<Void> deletePostCommentReaction(@PathVariable(name = "commentId") Long commentId,
-                                                                              @RequestBody PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
+    public ResponseEntity<ApiResponse<?>> deletePostCommentReaction(@PathVariable(name = "commentId") Long commentId,
+                                                                    @RequestBody PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
         postCommentReactionService.deletePostCommentReaction(commentId, postCommentReactionCreateRequest);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.success(null);
     }
 }

--- a/src/main/java/ussum/homepage/application/reaction/controller/PostCommentReactionController.java
+++ b/src/main/java/ussum/homepage/application/reaction/controller/PostCommentReactionController.java
@@ -1,18 +1,46 @@
 package ussum.homepage.application.reaction.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ussum.homepage.application.reaction.service.PostCommentReactionService;
+import ussum.homepage.application.reaction.service.dto.request.CreatePostCommentReactionReq;
 import ussum.homepage.application.reaction.service.dto.request.PostCommentReactionCreateRequest;
 import ussum.homepage.application.reaction.service.dto.response.PostCommentReactionResponse;
 import ussum.homepage.global.ApiResponse;
+import ussum.homepage.global.config.auth.UserId;
 
 @RequiredArgsConstructor
 @RequestMapping
 @RestController
+@Tag(name = "post_comment_reaction", description = "게시물 댓글 반응 api")
 public class PostCommentReactionController {
     private final PostCommentReactionService postCommentReactionService;
 
+    @Operation(summary = "게시물 댓글 반응 통합 api", description = """
+            게시물 댓글 반응을 위한 통합 api입니다.
+            
+            요청 json으로 like 또는 unlike를 받습니다.
+            
+            ex. like를 Request에 넣어서 요청을 하면 댓글 좋아요가 생성되고, 동일한 요청을 한번더 요청하면 이전에 눌렀던 댓긇 좋아요가 취소됩니다.
+            
+            """)
+    @PostMapping("/toggle/posts/{commentId}")
+    public ResponseEntity<ApiResponse<?>> togglePostCommentReaction(@UserId Long userId,
+                                                             @PathVariable(name = "commentId") Long commentId,
+                                                             @RequestBody CreatePostCommentReactionReq createPostCommentReactionReq) {
+        postCommentReactionService.postCommentReactionToggle(userId, commentId, createPostCommentReactionReq);
+        return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "게시물 댓글 반응 생성 api", description = """
+            게시물 댓글 반응을 등록하기 위한 api입니다.
+            
+            요청 json으로 like 또는 unlike를 받습니다.
+            
+            """)
     @PostMapping("/boards/posts/comments/{commentId}/reactions")
     public ApiResponse<Void> createPostCommentReaction(@PathVariable(name = "commentId") Long commentId,
                                                                               @RequestBody PostCommentReactionCreateRequest postCommentReactionCreateRequest) {
@@ -21,6 +49,12 @@ public class PostCommentReactionController {
         return ApiResponse.onSuccess(null);
     }
 
+    @Operation(summary = "게시물 댓글 반응 삭제 api", description = """
+            게시물 댓글 반응을 삭제하기 위한 api입니다.
+            
+            요청 json으로 like 또는 unlike를 받습니다.
+            
+            """)
     @DeleteMapping("/boards/posts/comments/{commentId}/reactions")
     public ApiResponse<Void> deletePostCommentReaction(@PathVariable(name = "commentId") Long commentId,
                                                                               @RequestBody PostCommentReactionCreateRequest postCommentReactionCreateRequest) {

--- a/src/main/java/ussum/homepage/application/reaction/controller/PostReactionController.java
+++ b/src/main/java/ussum/homepage/application/reaction/controller/PostReactionController.java
@@ -42,10 +42,10 @@ public class PostReactionController {
             
             """)
     @PostMapping("/boards/posts/{postId}/reactions")
-    public ApiResponse<Void> createPostReaction(@PathVariable(name = "postId") Long postId,
+    public ResponseEntity<ApiResponse<?>> createPostReaction(@PathVariable(name = "postId") Long postId,
                                                 @RequestBody PostReactionCreateRequest postReactionCreateRequest) {
-        PostReactionResponse postReaction = postReactionService.createPostReaction(postId, postReactionCreateRequest);
-        return ApiResponse.onSuccess(null);
+        postReactionService.createPostReaction(postId, postReactionCreateRequest);
+        return ApiResponse.success(null);
     }
 
     @Operation(summary = "게시물 반응 삭제 api", description = """
@@ -55,10 +55,10 @@ public class PostReactionController {
             
             """)
     @DeleteMapping("/boards/posts/{postId}/reactions")
-    public ApiResponse<Void> deletePostReaction(@UserId Long userId, @PathVariable(name = "postId") Long postId,
+    public ResponseEntity<ApiResponse<?>> deletePostReaction(@UserId Long userId, @PathVariable(name = "postId") Long postId,
                                                 @RequestBody PostReactionCreateRequest postReactionCreateRequest) {
         postReactionService.deletePostReaction(userId, postId, postReactionCreateRequest);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.success(null);
 
     }
 }

--- a/src/main/java/ussum/homepage/application/reaction/controller/PostReactionController.java
+++ b/src/main/java/ussum/homepage/application/reaction/controller/PostReactionController.java
@@ -21,11 +21,20 @@ import ussum.homepage.application.reaction.service.dto.response.PostReactionResp
 public class PostReactionController {
     private final PostReactionService postReactionService;
 
+    @Operation(summary = "게시물 반응 통합 api", description = """
+            게시물 반응을 위한 통합 api입니다.
+            
+            요청 json으로 like 또는 unlike를 받습니다.
+            
+            ex. like를 Request에 넣어서 요청을 하면 좋아요가 생성되고, 동일한 요청을 한번더 요청하면 이전에 눌렀던 좋아요가 취소됩니다.
+            
+            """)
     @PostMapping("/toggle/{postId}")
     public ResponseEntity<ApiResponse<?>> togglePostReaction(@UserId Long userId, @PathVariable(name = "postId")Long postId, @RequestBody CreatePostReactionReq createPostReactionReq) {
         postReactionService.postReactionToggle(userId, postId, createPostReactionReq);
         return ApiResponse.success(null);
     }
+
     @Operation(summary = "게시물 반응 생성 api", description = """
             게시물 반응을 등록하기 위한 api입니다.
             

--- a/src/main/java/ussum/homepage/application/reaction/service/dto/request/CreatePostCommentReactionReq.java
+++ b/src/main/java/ussum/homepage/application/reaction/service/dto/request/CreatePostCommentReactionReq.java
@@ -1,0 +1,16 @@
+package ussum.homepage.application.reaction.service.dto.request;
+
+import ussum.homepage.domain.reaction.PostCommentReaction;
+
+public record CreatePostCommentReactionReq(
+        String reaction
+) {
+    public PostCommentReaction toDomain(Long commentId, Long userId) {
+        return PostCommentReaction.of(
+                null,
+                commentId,
+                userId,
+                reaction
+        );
+    }
+}

--- a/src/main/java/ussum/homepage/domain/post/service/PostReader.java
+++ b/src/main/java/ussum/homepage/domain/post/service/PostReader.java
@@ -44,7 +44,6 @@ public class PostReader {
     }
 
     public Page<Post> getPostListBySearch(Pageable pageable, String boardCode, String q, String categoryCode) {
-        return postRepository.findBySearchCriteria(
-                pageable, boardCode, q, categoryCode);
+        return postRepository.findBySearchCriteria(pageable, boardCode, q, categoryCode);
     }
 }

--- a/src/main/java/ussum/homepage/domain/reaction/PostCommentReaction.java
+++ b/src/main/java/ussum/homepage/domain/reaction/PostCommentReaction.java
@@ -11,12 +11,16 @@ public class PostCommentReaction {
     private Long id;
     private Long postCommentId;
     private Long userId;
-    private String reactionType;
+    private String reaction;
 
     public static PostCommentReaction of(Long id,
                                          Long postCommentId,
                                          Long userId,
-                                         String reactionType) {
-        return new PostCommentReaction(id, postCommentId, userId, reactionType);
+                                         String reaction) {
+        return new PostCommentReaction(id, postCommentId, userId, reaction);
+    }
+
+    public void updateCommentReaction(PostCommentReaction newReaction) {
+        this.reaction = newReaction.getReaction();
     }
 }

--- a/src/main/java/ussum/homepage/domain/reaction/PostCommentReactionRepository.java
+++ b/src/main/java/ussum/homepage/domain/reaction/PostCommentReactionRepository.java
@@ -8,5 +8,6 @@ public interface PostCommentReactionRepository {
     void delete(PostCommentReaction postCommentReaction);
     Optional<PostCommentReaction> findByCommentIdAndUserId(Long commentId, Long userId, String reaction);
     List<PostCommentReaction> findAllPostCommentByCommentId(Long commentId);
+    Optional<PostCommentReaction> findByUserIdAndCommentId(Long userId, Long commentId);
 }
 

--- a/src/main/java/ussum/homepage/domain/reaction/service/PostCommentReactionModifier.java
+++ b/src/main/java/ussum/homepage/domain/reaction/service/PostCommentReactionModifier.java
@@ -2,6 +2,7 @@ package ussum.homepage.domain.reaction.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import ussum.homepage.domain.postlike.PostReaction;
 import ussum.homepage.domain.reaction.PostCommentReaction;
 import ussum.homepage.domain.reaction.PostCommentReactionRepository;
 
@@ -12,5 +13,10 @@ public class PostCommentReactionModifier {
 
     public void deletePostCommentReaction(PostCommentReaction postCommentReaction) {
         postCommentReactionRepository.delete(postCommentReaction);
+    }
+
+    public void updatePostCommentReaction(PostCommentReaction existingReaction, PostCommentReaction newReaction){
+        existingReaction.updateCommentReaction(newReaction);
+        postCommentReactionRepository.save(existingReaction);
     }
 }

--- a/src/main/java/ussum/homepage/domain/reaction/service/PostCommentReactionReader.java
+++ b/src/main/java/ussum/homepage/domain/reaction/service/PostCommentReactionReader.java
@@ -6,6 +6,8 @@ import ussum.homepage.domain.reaction.PostCommentReaction;
 import ussum.homepage.domain.reaction.PostCommentReactionRepository;
 import ussum.homepage.domain.reaction.exception.PostCommentReactionException;
 
+import java.util.Optional;
+
 import static ussum.homepage.global.error.status.ErrorStatus.POST_COMMENT_REACTION_NOT_FOUND;
 
 @Service
@@ -16,5 +18,9 @@ public class PostCommentReactionReader {
     public PostCommentReaction getPostCommentReactionWithCommentIdAndUserId(Long commentId, Long userId, String reaction) {
         return postCommentReactionRepository.findByCommentIdAndUserId(commentId, userId, reaction)
                 .orElseThrow(() -> new PostCommentReactionException(POST_COMMENT_REACTION_NOT_FOUND));
+    }
+
+    public Optional<PostCommentReaction> getPostCommentReactionByUserIdAndCommentId(Long userId, Long commentId) {
+        return postCommentReactionRepository.findByUserIdAndCommentId(userId, commentId);
     }
 }

--- a/src/main/java/ussum/homepage/infra/jpa/reaction/PostCommentReactionMapper.java
+++ b/src/main/java/ussum/homepage/infra/jpa/reaction/PostCommentReactionMapper.java
@@ -23,7 +23,7 @@ public class PostCommentReactionMapper {
                 postCommentReaction.getId(),
                 PostCommentEntity.from(postCommentReaction.getPostCommentId()),
                 UserEntity.from(postCommentReaction.getUserId()),
-                Reaction.getEnumReactionFromStringReaction(postCommentReaction.getReactionType())
+                Reaction.getEnumReactionFromStringReaction(postCommentReaction.getReaction())
         );
     }
 


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- searchBoardPost api querydsl 적용하여 Pagenation 적용
  - infra단 에서 반환을 PageableExecutionUtils로 하였는데 그 이유는 아래와 같음
> PageableExecutionUtils을 사용하면 단순 new PageImpl()을 사용했을 때 보다 성능 최적화 이점이 있습니다. PageableExecutionUtils 클래스는 내부에 getPage()라는 단 하나의 (정적) 메서드를 가집니다.
  1. 첫 번째 페이지이면서 content 크기가 한 페이지의 사이즈보다 작을 때 (ex, content:3개, page 크기: 10)
  2. 마지막 페이지일 때 (getOffset이 0이 아니면서, content 크기가 한 페이지의 사이즈보다 작을 때) totalSupplier 대신 content의 size와 offset 값으로 total 값을 대신함
  3. 이럴때는 count 쿼리가 직접 나가지 않기 때문에 성능상의 이점
  **ref : https://junior-datalist.tistory.com/342**

- searchBoardPost 반환 값에서 total 값은 원래 페이지에서 반환되는 데이터의 갯수와는 상관없이 전체 갯수를 나타냈는데, 이를 페이지당 반환 갯수로 변경함

- api Response format 변경 -> onSuccess 메소드를 사용하여 반환하는 것이 아닌 success메소드(반환값이
ResponseEntity<ApiResponse<>>)를 사용하여 반환하게 함 

- 기존에 Create, Delete로 나누어져 있던 PostCommentReaction api를 toggle 형식으로 하나의 api로 통합함 

---

### ✏️ 관련 이슈(선택 사항)
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #38 

---

### 코드 리뷰 받고 싶은 부분
cc1f03fbdde94047f80f69795b3c003ea0526597

---




