### PR TITLE
[refactor] #44 청원게시물 OnGoingStatus 로직 수정

### DIFF
--- a/src/main/java/ussum/homepage/application/comment/service/CommentService.java
+++ b/src/main/java/ussum/homepage/application/comment/service/CommentService.java
@@ -18,6 +18,7 @@ import ussum.homepage.domain.comment.service.PostCommentReader;
 import ussum.homepage.domain.group.Group;
 import ussum.homepage.domain.group.service.GroupReader;
 import ussum.homepage.domain.member.Member;
+import ussum.homepage.domain.member.service.MemberManager;
 import ussum.homepage.domain.member.service.MemberReader;
 import ussum.homepage.infra.jpa.comment.entity.CommentType;
 
@@ -29,8 +30,8 @@ public class CommentService {
     private final PostCommentFormatter postCommentFormatter;
     private final PostCommentAppender postCommentAppender;
     private final PostCommentModifier postCommentModifier;
-    private final GroupReader groupReader;
     private final MemberReader memberReader;
+    private final MemberManager memberManager;
 
     public PostCommentListResponse getCommentList(Long postId, int page, int take, String type){
         Page<PostComment> commentList = postCommentReader.getPostCommentList(setPageable(page, take), postId);
@@ -39,13 +40,7 @@ public class CommentService {
 
     @Transactional
     public PostCommentResponse createComment(Long userId, Long postId, PostCommentCreateRequest postCommentCreateRequest) {
-        String commentType = CommentType.GENERAL.getStringCommentType();
-        Member member = memberReader.getMemberWithUserId(userId);
-        Group group = groupReader.getGroupByGroupId(member.getGroupId());
-        if (group.getGroupCode().equals("중앙운영위원회")) {
-            commentType = CommentType.OFFICIAL.getStringCommentType();
-        }
-
+        String commentType = memberManager.getCommentType(userId);
         PostComment postComment = postCommentAppender.createPostComment(postCommentCreateRequest.toDomain(userId, postId, commentType));
         return postCommentFormatter.format(postComment, userId);
     }

--- a/src/main/java/ussum/homepage/application/post/service/PostManageService.java
+++ b/src/main/java/ussum/homepage/application/post/service/PostManageService.java
@@ -45,12 +45,12 @@ public class PostManageService {
             "청원게시판", PetitionPostResponse::of
     );
 
-    private final Map<String, PostDetailFunction<Post, Boolean, String, Integer, String, String, String, String, ? extends PostDetailResDto>> postDetailResponseMap = Map.of(
-            "공지사항게시판", (post, isAuthor, authorName, ignored, categoryName, another_ignored, imageList, fileList) -> NoticePostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
-            "분실물게시판", (post, isAuthor, authorName, ignored, categoryName, another_ignored1, imageList, another_ignored2) -> LostPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList),
-            "제휴게시판", (post, isAuthor, authorName, ignored, categoryName, another_ignored, imageList, fileList) -> PartnerPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
-            "감사기구게시판", (post, isAuthor, authorName, ignored, categoryName, another_ignored, imageList, fileList) -> AuditPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
-            "청원게시판", (post, isAuthor, authorName, likeCount, petitionStatus, onGoingStatus, imageList, ignored) -> PetitionPostDetailResponse.of(post, isAuthor, authorName, likeCount, petitionStatus, onGoingStatus)
+    private final Map<String, PostDetailFunction<Post, Boolean, String, Integer, String, String, String, ? extends PostDetailResDto>> postDetailResponseMap = Map.of(
+            "공지사항게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, fileList) -> NoticePostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
+            "분실물게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, another_ignored) -> LostPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList),
+            "제휴게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, fileList) -> PartnerPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
+            "감사기구게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, fileList) -> AuditPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
+            "청원게시판", (post, isAuthor, authorName, likeCount, onGoingStatus, imageList, ignored) -> PetitionPostDetailResponse.of(post, isAuthor, authorName, likeCount, onGoingStatus, imageList)
     );
 
 
@@ -85,8 +85,6 @@ public class PostManageService {
     public PostDetailRes<?> getPost(PostUserRequest postUserRequest, String boardCode, Long postId) {
         Board board = boardReader.getBoardWithBoardCode(boardCode);
         Post post = postReader.getPostWithBoardCodeAndPostId(boardCode, postId);
-        String postOnGoingStatus = postStatusProcessor.processStatus(post);//게시물 진행상태 check 로직
-        System.out.println("postOnGoingStatus = " + postOnGoingStatus);
         Category category = categoryReader.getCategoryById(post.getCategoryId());
         User user = userReader.getUserWithId(post.getUserId());
 
@@ -98,7 +96,7 @@ public class PostManageService {
         List<String> fileList = postFileReader.getPostFileListByFileType(postFileList);
 
 
-        PostDetailFunction<Post, Boolean, String, Integer, String, String, String, String, ? extends PostDetailResDto> responseFunction = postDetailResponseMap.get(board.getName());
+        PostDetailFunction<Post, Boolean, String, Integer, String, String, String, ? extends PostDetailResDto> responseFunction = postDetailResponseMap.get(board.getName());
 
         if (responseFunction == null) {
             throw new GeneralException(ErrorStatus.INVALID_BOARDCODE);
@@ -107,11 +105,12 @@ public class PostManageService {
         PostDetailResDto response = null;
         if (board.getName().equals("청원게시판")) {
             Integer likeCount = postReactionReader.countPostReactionsByType(post.getId(), "like");
-            response = responseFunction.apply(post, isAuthor, user.getName(), likeCount, category.getName(), postOnGoingStatus, imageList, null);
+            String postOnGoingStatus = postStatusProcessor.processStatus(post);
+            response = responseFunction.apply(post, isAuthor, user.getName(), likeCount, postOnGoingStatus, imageList, null);
         } else if (board.getName().equals("제휴게시판") || board.getName().equals("공지사항게시판") || board.getName().equals("감사기구게시판")) {
-            response = responseFunction.apply(post, isAuthor, user.getName(), null, category.getName(), null, imageList, fileList);
+            response = responseFunction.apply(post, isAuthor, user.getName(), null, category.getName(), imageList, fileList);
         } else if (board.getName().equals("분실물게시판")) {
-            response = responseFunction.apply(post, isAuthor, user.getName(), null, category.getName(), null, imageList, null); //분실물 게시판은 파일첨부 제외
+            response = responseFunction.apply(post, isAuthor, user.getName(), null, category.getName(), imageList, null); //분실물 게시판은 파일첨부 제외
         }
 
         return PostDetailRes.of(response);

--- a/src/main/java/ussum/homepage/application/post/service/dto/response/postDetail/PetitionPostDetailResponse.java
+++ b/src/main/java/ussum/homepage/application/post/service/dto/response/postDetail/PetitionPostDetailResponse.java
@@ -3,34 +3,37 @@ package ussum.homepage.application.post.service.dto.response.postDetail;
 import lombok.Builder;
 import lombok.Getter;
 import ussum.homepage.domain.post.Post;
+import ussum.homepage.infra.jpa.post.entity.OngoingStatus;
+
+import java.util.List;
 
 @Getter
 public class PetitionPostDetailResponse extends PostDetailResDto {
     private final Integer likeCount;
-    private final String status;
     private final String onGoingStatus;
+    private final List<String> imageList;
 
     @Builder
     private PetitionPostDetailResponse(Long postId, String categoryName, String authorName, String title, String content, String createdAt, Boolean isAuthor,
-                                       Integer likeCount, String status, String onGoingStatus) {
+                                       Integer likeCount, String onGoingStatus, List<String> imageList) {
         super(postId, categoryName, authorName, title, content, createdAt, isAuthor);
         this.likeCount = likeCount;
-        this.status = status;
         this.onGoingStatus = onGoingStatus;
+        this.imageList = imageList;
     }
 
-    public static PetitionPostDetailResponse of(Post post, Boolean isAuthor, String authorName, Integer likeCount, String petitionStatus, String onGoingStatus) {
+    public static PetitionPostDetailResponse of(Post post, Boolean isAuthor, String authorName, Integer likeCount, String onGoingStatus, List<String> imageList) {
         return PetitionPostDetailResponse.builder()
                 .postId(post.getId())
-                .categoryName(petitionStatus)
+                .categoryName(OngoingStatus.toKorean(onGoingStatus))
                 .authorName(authorName)
                 .title(post.getTitle())
                 .content(post.getContent())
                 .createdAt(post.getCreatedAt())
                 .isAuthor(isAuthor)
                 .likeCount(likeCount)
-                .status(petitionStatus)
-                .onGoingStatus(post.getOnGoingStatus())
+                .onGoingStatus(onGoingStatus)
+                .imageList(imageList)
                 .build();
     }
 

--- a/src/main/java/ussum/homepage/domain/member/MemberRepository.java
+++ b/src/main/java/ussum/homepage/domain/member/MemberRepository.java
@@ -4,4 +4,6 @@ import java.util.Optional;
 
 public interface MemberRepository {
     Optional<Member> findByUserId(Long userId);
+    Optional<Member> findCentralOperationCommitteeMember(Long userId);
+
 }

--- a/src/main/java/ussum/homepage/domain/member/service/MemberManager.java
+++ b/src/main/java/ussum/homepage/domain/member/service/MemberManager.java
@@ -3,6 +3,7 @@ package ussum.homepage.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import ussum.homepage.domain.member.MemberRepository;
+import ussum.homepage.infra.jpa.comment.entity.CommentType;
 
 
 @Service
@@ -14,6 +15,12 @@ public class MemberManager {
         return memberRepository.findByUserId(userId)
                 .map(member -> "CENTRAL_OPERATION_COMMITTEE".equals(member.getMemberCode()))
                 .orElse(false);
+    }
+
+    public String getCommentType(Long userId) {
+        return memberRepository.findCentralOperationCommitteeMember(userId)
+                .map(member -> CommentType.OFFICIAL.getStringCommentType())
+                .orElse(CommentType.GENERAL.getStringCommentType());
     }
 
 }

--- a/src/main/java/ussum/homepage/domain/member/service/MemberReader.java
+++ b/src/main/java/ussum/homepage/domain/member/service/MemberReader.java
@@ -6,6 +6,8 @@ import ussum.homepage.domain.member.Member;
 import ussum.homepage.domain.member.MemberRepository;
 import ussum.homepage.domain.member.exception.MemberNotFoundException;
 
+import java.util.Optional;
+
 import static ussum.homepage.global.error.status.ErrorStatus.MEMBER_NOT_FOUND;
 
 @Service
@@ -16,4 +18,5 @@ public class MemberReader {
     public Member getMemberWithUserId(Long userId) {
         return memberRepository.findByUserId(userId).orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
     }
+
 }

--- a/src/main/java/ussum/homepage/domain/post/PostRepository.java
+++ b/src/main/java/ussum/homepage/domain/post/PostRepository.java
@@ -16,5 +16,5 @@ public interface PostRepository {
     void delete(Post post);
     Page<Post> findBySearchCriteria(Pageable pageable,String boardCode, String q, String categoryCode);
     Page<SimplePostResponse> findPostDtoListByBoardCode(String boardCode, Pageable pageable);
-    Post updatePostOngoingStatus(Long postId, String onGoingStatus);
+    Post updatePostOngoingStatus(Long postId, String onGoingStatus, Category category);
 }

--- a/src/main/java/ussum/homepage/domain/post/service/PostStatusProcessor.java
+++ b/src/main/java/ussum/homepage/domain/post/service/PostStatusProcessor.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import ussum.homepage.domain.comment.service.PostCommentReader;
 import ussum.homepage.domain.member.service.MemberManager;
+import ussum.homepage.domain.post.Category;
 import ussum.homepage.domain.post.Post;
 import ussum.homepage.domain.post.PostRepository;
 import ussum.homepage.domain.postlike.service.PostReactionReader;
@@ -18,6 +19,7 @@ public class PostStatusProcessor {
     private final PostCommentReader postCommentReader;
     private final PostReactionReader postReactionReader;
     private final MemberManager memberManager;
+    private final CategoryReader categoryReader;
 
     public String processStatus(Post post) {
         //현재 게시물 상태 checking
@@ -38,7 +40,8 @@ public class PostStatusProcessor {
      * 해당 로직은 실제 청원게시물의 OnGoingStatus를 변경하는 로직
      */
     public String updatePostOngoingStatus(Long postId, String onGoingStatus) {
-        return postRepository.updatePostOngoingStatus(postId, onGoingStatus).getOnGoingStatus();
+        Category category = categoryReader.getCategoryWithCode(onGoingStatus);
+        return postRepository.updatePostOngoingStatus(postId, onGoingStatus, category).getOnGoingStatus();
     }
 
     /**

--- a/src/main/java/ussum/homepage/domain/post/service/PostStatusProcessor.java
+++ b/src/main/java/ussum/homepage/domain/post/service/PostStatusProcessor.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import ussum.homepage.domain.comment.service.PostCommentReader;
 import ussum.homepage.domain.member.service.MemberManager;
-import ussum.homepage.domain.member.service.MemberReader;
 import ussum.homepage.domain.post.Post;
 import ussum.homepage.domain.post.PostRepository;
 import ussum.homepage.domain.postlike.service.PostReactionReader;
@@ -18,22 +17,19 @@ public class PostStatusProcessor {
     private final PostRepository postRepository;
     private final PostCommentReader postCommentReader;
     private final PostReactionReader postReactionReader;
-    private final MemberReader memberReader;
     private final MemberManager memberManager;
 
     public String processStatus(Post post) {
         //현재 게시물 상태 checking
-        String currentStatus = post.getOnGoingStatus();
+        String currentStatus = Optional.ofNullable(post.getOnGoingStatus())
+                .orElseThrow(() -> new IllegalStateException("Post status cannot be null"));
         //게시물의 좋아요 수를 미리 가져옴
         Integer likeCountOfPost = postReactionReader.countPostReactionsByType(post.getId(), "like");
-
         switch (currentStatus) {
             case "IN_PROGRESS":
-                handleInProgressStatus(post,likeCountOfPost);
-                break;
+                return handleInProgressStatus(post,likeCountOfPost);
             case "RECEIVED":
-                handleReceivedStatus(post);
-                break;
+                return handleReceivedStatus(post);
         }
         return currentStatus;
     }

--- a/src/main/java/ussum/homepage/domain/post/service/formatter/PostDetailFunction.java
+++ b/src/main/java/ussum/homepage/domain/post/service/formatter/PostDetailFunction.java
@@ -3,7 +3,7 @@ package ussum.homepage.domain.post.service.formatter;
 import java.util.List;
 
 @FunctionalInterface
-public interface PostDetailFunction<T, K, U, V, W, O, Q, Y, R> {
-    R apply(T t, K k, U u, V v, W w, O o, List<Q> q, List<Y> y);
+public interface PostDetailFunction<T, K, U, V, W, Q, Y, R> {
+    R apply(T t, K k, U u, V v, W w, List<Q> q, List<Y> y);
 }
 

--- a/src/main/java/ussum/homepage/global/config/SecurityConfig.java
+++ b/src/main/java/ussum/homepage/global/config/SecurityConfig.java
@@ -32,9 +32,9 @@ public class SecurityConfig {
             "/onboarding/**",
             "/swagger-ui/**",
             "/swagger-resources/**",
-            "/v3/api-docs/**"
-            ,"/board/{boardCode}/posts/{postId}"
-            ,"/board/posts/{postId}/comments"
+            "/v3/api-docs/**",
+            "/board/{boardCode}/posts/{postId}",
+            "/board/posts/{postId}/comments"
     };
 
 

--- a/src/main/java/ussum/homepage/global/error/status/ErrorStatus.java
+++ b/src/main/java/ussum/homepage/global/error/status/ErrorStatus.java
@@ -70,6 +70,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_COMMENT_TYPE(HttpStatus.BAD_REQUEST,"ENUM_011","유효하지 않은 COMMENT TYPE입니다."),
     INVALID_STATUS(HttpStatus.BAD_REQUEST,"ENUM_012","유효하지 않은 STATUS입니다."),
     INVALID_ONGOING_STATUS(HttpStatus.BAD_REQUEST,"ENUM_013","유효하지 않은 ONGOING_STATUS입니다."),
+    WRONG_TRANSLATED_TO_KOREAN(HttpStatus.BAD_REQUEST,"ENUM_014","ONGOING_STATUS가 한국어로 잘못변환되었습니다."),
 
     /**
      * 401 Unauthorized, Token 관련 에러

--- a/src/main/java/ussum/homepage/infra/jpa/member/MemberRepositoryImpl.java
+++ b/src/main/java/ussum/homepage/infra/jpa/member/MemberRepositoryImpl.java
@@ -14,9 +14,15 @@ public class MemberRepositoryImpl implements MemberRepository {
     private final MemberJpaRepository memberJpaRepository;
     private final MemberMapper memberMapper;
 
-
     @Override
     public Optional<Member> findByUserId(Long userId) {
         return memberJpaRepository.findByUserId(userId).map(memberMapper::toDomain);
+    }
+
+    // MemberCode가 CENTRAL_OPERATION_COMMITTEE인 경우의 Member를 반환
+    public Optional<Member> findCentralOperationCommitteeMember(Long userId) {
+        return memberJpaRepository.findByUserId(userId)
+                .map(memberMapper::toDomain)
+                .filter(member -> "CENTRAL_OPERATION_COMMITTEE".equals(member.getMemberCode()));
     }
 }

--- a/src/main/java/ussum/homepage/infra/jpa/post/PostMapper.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/PostMapper.java
@@ -3,20 +3,22 @@ package ussum.homepage.infra.jpa.post;
 import org.springframework.stereotype.Component;
 import ussum.homepage.application.post.service.dto.response.SimplePostResponse;
 import ussum.homepage.application.post.service.dto.response.TopLikedPostListResponse;
-import ussum.homepage.domain.post.Board;
-import ussum.homepage.domain.post.Category;
 import ussum.homepage.domain.post.Post;
-import ussum.homepage.domain.user.User;
 import ussum.homepage.global.common.PageInfo;
 import ussum.homepage.infra.jpa.post.entity.*;
 import ussum.homepage.infra.jpa.user.entity.UserEntity;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 public class PostMapper {
     public Post toDomain(PostEntity postEntity){
+        String onGoingStatus = Optional.ofNullable(postEntity.getOngoingStatus())
+                .map(OngoingStatus::getStringOnGoingStatus)
+                .orElse(null);
+
         return Post.of(
                 postEntity.getId(),
                 postEntity.getTitle(),
@@ -24,7 +26,7 @@ public class PostMapper {
                 postEntity.getViewCount(),
                 postEntity.getThumbnailImage(),
                 postEntity.getStatus().getStringStatus(),
-                postEntity.getOngoingStatus().getStringOnGoingStatus(),
+                onGoingStatus,
                 postEntity.getCreatedAt(),
                 postEntity.getUpdatedAt(),
                 postEntity.getLastEditedAt(),
@@ -35,15 +37,10 @@ public class PostMapper {
     }
 
     public PostEntity toEntity(Post post, UserEntity user, BoardEntity board, CategoryEntity category) {
-        LocalDateTime lastEditedAt = null;
-//        LocalDateTime deletedAt = null;
-
-        if (post.getLastEditedAt() != null && !"null".equals(post.getLastEditedAt())) {
-            lastEditedAt = LocalDateTime.parse(post.getLastEditedAt());
-        }
-//        if (post.getDeletedAt() != null && !"null".equals(post.getDeletedAt())) {
-//            deletedAt = LocalDateTime.parse(post.getDeletedAt());
-//        }
+        LocalDateTime lastEditedAt = Optional.ofNullable(post.getLastEditedAt())
+                .filter(date -> !"null".equals(date))
+                .map(LocalDateTime::parse)
+                .orElse(null);
 
         return PostEntity.of(
                 post.getId(),

--- a/src/main/java/ussum/homepage/infra/jpa/post/PostRepositoryImpl.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/PostRepositoryImpl.java
@@ -10,7 +10,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import ussum.homepage.application.post.service.dto.response.SimplePostResponse;
+import ussum.homepage.domain.post.Category;
 import ussum.homepage.domain.post.exception.PostException;
+import ussum.homepage.domain.post.service.CategoryReader;
 import ussum.homepage.infra.jpa.post.dto.SimplePostDto;
 import ussum.homepage.domain.post.Post;
 import ussum.homepage.domain.post.PostRepository;
@@ -44,6 +46,7 @@ public class PostRepositoryImpl implements PostRepository {
     private final UserJpaRepository userJpaRepository;
     private final PostMapper postMapper;
     private final JPAQueryFactory queryFactory;
+    private final CategoryMapper categoryMapper;
 
     @Override
     public Optional<Post> findById(Long postId) {
@@ -184,10 +187,12 @@ public class PostRepositoryImpl implements PostRepository {
     }
 
     @Override
-    public Post updatePostOngoingStatus(Long postId, String onGoingStatus) {
+    public Post updatePostOngoingStatus(Long postId, String onGoingStatus, Category category) {
         return postJpaRepository.findById(postId)
                 .map(postEntity -> {
-                    postEntity.updateStatus(OngoingStatus.getEnumOngoingStatusFromStringOngoingStatus(onGoingStatus));
+                    postEntity.updateStatusAndCategoryCode(
+                            OngoingStatus.getEnumOngoingStatusFromStringOngoingStatus(onGoingStatus), categoryMapper.toEntity(category)
+                    );
                     return postMapper.toDomain(postJpaRepository.save(postEntity));
                 })
                 .orElseThrow(() -> new PostException(POST_ONGOING_STATUS_IS_NOT_UPDATED));

--- a/src/main/java/ussum/homepage/infra/jpa/post/entity/CategoryCode.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/entity/CategoryCode.java
@@ -25,7 +25,7 @@ public enum CategoryCode {
     HOUSING("HOUSING"),
 
     //청원 카테고리(진행중, 접수완료, 답변완료 ,종료됨)
-    PROGRESS("PROGRESS"),
+    IN_PROGRESS("IN_PROGRESS"),
     RECEIVED("RECEIVED"),
     ANSWERED("ANSWERED"),
     COMPLETED("COMPLETED");

--- a/src/main/java/ussum/homepage/infra/jpa/post/entity/OngoingStatus.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/entity/OngoingStatus.java
@@ -7,6 +7,7 @@ import ussum.homepage.global.error.exception.InvalidValueException;
 import java.util.Arrays;
 
 import static ussum.homepage.global.error.status.ErrorStatus.INVALID_ONGOING_STATUS;
+import static ussum.homepage.global.error.status.ErrorStatus.WRONG_TRANSLATED_TO_KOREAN;
 
 @RequiredArgsConstructor
 @Getter
@@ -23,5 +24,20 @@ public enum OngoingStatus {
                 .filter(ongoingStatus -> ongoingStatus.stringOnGoingStatus.equals(stringOnGoingStatus))
                 .findFirst()
                 .orElseThrow(() -> new InvalidValueException(INVALID_ONGOING_STATUS));
+    }
+
+    public static String toKorean(String stringOnGoingStatus) {
+        switch (stringOnGoingStatus) {
+            case "IN_PROGRESS":
+                return "진행중";
+            case "RECEIVED":
+                return "접수완료";
+            case "ANSWERED":
+                return "답변완료";
+            case "COMPLETED":
+                return "종료됨";
+            default:
+                throw new InvalidValueException(WRONG_TRANSLATED_TO_KOREAN);
+        }
     }
 }

--- a/src/main/java/ussum/homepage/infra/jpa/post/entity/PostEntity.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/entity/PostEntity.java
@@ -1,6 +1,7 @@
 package ussum.homepage.infra.jpa.post.entity;
 import jakarta.persistence.*;
 import lombok.*;
+import ussum.homepage.domain.post.Category;
 import ussum.homepage.infra.jpa.BaseEntity;
 import ussum.homepage.infra.jpa.user.entity.UserEntity;
 
@@ -57,7 +58,8 @@ public class PostEntity extends BaseEntity {
         post.lastEditedAt = LocalDateTime.now();
     }
 
-    public void updateStatus(OngoingStatus newStatus) {
+    public void updateStatusAndCategoryCode(OngoingStatus newStatus, CategoryEntity updatedCategoryEntity) {
         this.ongoingStatus = newStatus;
+        this.categoryEntity = updatedCategoryEntity;
     }
 }


### PR DESCRIPTION
OnGoingStatus는 청원게시물에서만 쓰이기에 청원게시물 반환 분기문에 상태변경 로직을 포함시킴

### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 청원게시물 OnGoingStatus 로직 수정 -> 청원게시물 쪽만 필요하기에 청원게시물 조회 분기문에 포함시킴 [58a3b870d61be3a168aad9950e4a42d069594099]
- 청원 게시물의 CategoryCode는 OnGoingStatus와 동일함 [03159a1ab41952b3645394e8d5f7dc30674ecb00]
  - 그래서 PostEntity의 category_id도 바꿔줘야할 때  OnGoingStatus의 enum값과 동일한 CategoryCode (IN_PROGRESS, RECEIVED, ANSWERED, COMPLETED)를 찾아서 이것을 PostEntity의 category_id 와 매핑
  - 댓글 생성 시 "중앙운영위원회" 비교하는 로직 수정 [e65cb28]

---

### ✏️ 관련 이슈(선택 사항)
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #44 
- Ref : #49

---

### 코드 리뷰 받고 싶은 부분



---




