### PR TITLE
[refactor] #52 청원게시물 단건 조회 시 공식답변(댓글) 포함 및 게시물 파일 생성 경로 수정 

### DIFF
--- a/src/main/java/ussum/homepage/application/comment/service/CommentService.java
+++ b/src/main/java/ussum/homepage/application/comment/service/CommentService.java
@@ -15,12 +15,7 @@ import ussum.homepage.domain.comment.service.PostCommentAppender;
 import ussum.homepage.domain.comment.service.PostCommentFormatter;
 import ussum.homepage.domain.comment.service.PostCommentModifier;
 import ussum.homepage.domain.comment.service.PostCommentReader;
-import ussum.homepage.domain.group.Group;
-import ussum.homepage.domain.group.service.GroupReader;
-import ussum.homepage.domain.member.Member;
 import ussum.homepage.domain.member.service.MemberManager;
-import ussum.homepage.domain.member.service.MemberReader;
-import ussum.homepage.infra.jpa.comment.entity.CommentType;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +25,6 @@ public class CommentService {
     private final PostCommentFormatter postCommentFormatter;
     private final PostCommentAppender postCommentAppender;
     private final PostCommentModifier postCommentModifier;
-    private final MemberReader memberReader;
     private final MemberManager memberManager;
 
     public PostCommentListResponse getCommentList(Long postId, int page, int take, String type){

--- a/src/main/java/ussum/homepage/application/comment/service/dto/response/PostOfficialCommentResponse.java
+++ b/src/main/java/ussum/homepage/application/comment/service/dto/response/PostOfficialCommentResponse.java
@@ -7,15 +7,18 @@ public record PostOfficialCommentResponse(
         String authorName,
         String content,
         String commentType,
-        String lastEditedAt
+        String createdAt,
+        String lastEditedAt,
+        Boolean isAuthor
 ) {
-    public static PostOfficialCommentResponse of(PostComment postComment, String authorName, String commentType) {
+    public static PostOfficialCommentResponse of(PostComment postComment, String authorName, String commentType, Boolean isAuthor) {
         return new PostOfficialCommentResponse(
                 postComment.getId(),
                 authorName,
                 postComment.getContent(),
                 commentType,
-                postComment.getLastEditedAt()
-        );
+                postComment.getCreatedAt(),
+                postComment.getLastEditedAt(),
+                isAuthor);
     }
 }

--- a/src/main/java/ussum/homepage/application/post/controller/PostManageController.java
+++ b/src/main/java/ussum/homepage/application/post/controller/PostManageController.java
@@ -41,7 +41,7 @@ public class PostManageController {
         return ApiResponse.success(postManageService.createBoardPost(userId, boardCode, postCreateRequest));
     }
 
-    @PostMapping("/{boardCode}/posts/files")
+    @PostMapping("/{boardCode}/files")
     public ResponseEntity<ApiResponse<?>> createBoardPostFile(@UserId Long userId,
                                                               @PathVariable(name = "boardCode") String boardCode,
                                                               @RequestPart(value = "files") MultipartFile[] files,
@@ -58,7 +58,7 @@ public class PostManageController {
 
     @PostMapping("/userIdTest")
     public ResponseEntity<ApiResponse<?>> apiTest(@UserId Long userId) {
-        System.out.println("userId = " + userId);;
+        System.out.println("userId = " + userId);
         return null;
     }
 

--- a/src/main/java/ussum/homepage/application/post/controller/PostManageController.java
+++ b/src/main/java/ussum/homepage/application/post/controller/PostManageController.java
@@ -41,15 +41,11 @@ public class PostManageController {
         return ApiResponse.success(postManageService.createBoardPost(userId, boardCode, postCreateRequest));
     }
 
-    @PostMapping("/{boardCode}/upposts/files")
+    @PostMapping("/{boardCode}/posts/files")
     public ResponseEntity<ApiResponse<?>> createBoardPostFile(@UserId Long userId,
                                                               @PathVariable(name = "boardCode") String boardCode,
-                                                               @RequestPart(value = "files") MultipartFile[] files,
-                                                              @RequestParam(value = "type") String typeName){
-        System.out.println("boardCode = " + boardCode);
-        System.out.println("files = " + files);
-        System.out.println("typeName = " + typeName);
-        System.out.println("userId = " + userId);
+                                                              @RequestPart(value = "files") MultipartFile[] files,
+                                                              @RequestParam(value = "type") String typeName) {
         return ApiResponse.success(postManageService.createBoardPostFile(userId, boardCode, files, typeName));
     }
 

--- a/src/main/java/ussum/homepage/application/post/service/PostManageService.java
+++ b/src/main/java/ussum/homepage/application/post/service/PostManageService.java
@@ -5,9 +5,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ussum.homepage.application.comment.service.dto.response.PostCommentResponse;
+import ussum.homepage.application.comment.service.dto.response.PostOfficialCommentResponse;
 import ussum.homepage.application.post.service.dto.request.PostUserRequest;
 import ussum.homepage.application.post.service.dto.response.postDetail.*;
 import ussum.homepage.application.post.service.dto.response.postList.*;
+import ussum.homepage.domain.comment.PostComment;
+import ussum.homepage.domain.comment.service.PostCommentReader;
+import ussum.homepage.domain.comment.service.PostOfficialCommentFormatter;
+import ussum.homepage.domain.comment.service.formatter.PostCommentFormatter;
 import ussum.homepage.domain.post.Board;
 import ussum.homepage.domain.post.Category;
 import ussum.homepage.domain.post.Post;
@@ -35,7 +41,9 @@ public class PostManageService {
     private final CategoryReader categoryReader;
     private final UserReader userReader;
     private final PostFileReader postFileReader;
+    private final PostCommentReader postCommentReader;
     private final PostStatusProcessor postStatusProcessor;
+    private final PostOfficialCommentFormatter postOfficialCommentFormatter;
 
     private final Map<String, BiFunction<Post, Integer, ? extends PostListResDto>> postResponseMap = Map.of(
             "공지사항게시판", (post, ignored) -> NoticePostResponse.of(post),
@@ -45,14 +53,13 @@ public class PostManageService {
             "청원게시판", PetitionPostResponse::of
     );
 
-    private final Map<String, PostDetailFunction<Post, Boolean, String, Integer, String, String, String, ? extends PostDetailResDto>> postDetailResponseMap = Map.of(
-            "공지사항게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, fileList) -> NoticePostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
-            "분실물게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, another_ignored) -> LostPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList),
-            "제휴게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, fileList) -> PartnerPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
-            "감사기구게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, fileList) -> AuditPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
-            "청원게시판", (post, isAuthor, authorName, likeCount, onGoingStatus, imageList, ignored) -> PetitionPostDetailResponse.of(post, isAuthor, authorName, likeCount, onGoingStatus, imageList)
+    private final Map<String, PostDetailFunction<Post, Boolean, String, Integer, String, String, String, PostOfficialCommentResponse, ? extends PostDetailResDto>> postDetailResponseMap = Map.of(
+            "공지사항게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, fileList, another_ignored) -> NoticePostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
+            "분실물게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, another_ignored1, another_ignored2) -> LostPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList),
+            "제휴게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, fileList, another_ignored) -> PartnerPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
+            "감사기구게시판", (post, isAuthor, authorName, ignored, categoryName, imageList, fileList, another_ignored) -> AuditPostDetailResponse.of(post, isAuthor, authorName, categoryName, imageList, fileList),
+            "청원게시판", (post, isAuthor, authorName, likeCount, onGoingStatus, imageList, ignored, postOfficialCommentResponseList) -> PetitionPostDetailResponse.of(post, isAuthor, authorName, likeCount, onGoingStatus, imageList, postOfficialCommentResponseList)
     );
-
 
     public PostListRes<?> getPostList(int page, int take, String boardCode) {
         Board board = boardReader.getBoardWithBoardCode(boardCode);
@@ -96,7 +103,7 @@ public class PostManageService {
         List<String> fileList = postFileReader.getPostFileListByFileType(postFileList);
 
 
-        PostDetailFunction<Post, Boolean, String, Integer, String, String, String, ? extends PostDetailResDto> responseFunction = postDetailResponseMap.get(board.getName());
+        PostDetailFunction<Post, Boolean, String, Integer, String, String, String, PostOfficialCommentResponse, ? extends PostDetailResDto> responseFunction = postDetailResponseMap.get(board.getName());
 
         if (responseFunction == null) {
             throw new GeneralException(ErrorStatus.INVALID_BOARDCODE);
@@ -106,11 +113,15 @@ public class PostManageService {
         if (board.getName().equals("청원게시판")) {
             Integer likeCount = postReactionReader.countPostReactionsByType(post.getId(), "like");
             String postOnGoingStatus = postStatusProcessor.processStatus(post);
-            response = responseFunction.apply(post, isAuthor, user.getName(), likeCount, postOnGoingStatus, imageList, null);
+            List<PostComment> officialPostComments = postCommentReader.getCommentListWithPostIdAndCommentType(userId, postId, "OFFICIAL");
+            List<PostOfficialCommentResponse> postOfficialCommentResponses = officialPostComments.stream()
+                    .map(postOfficialComment -> postOfficialCommentFormatter.format(postOfficialComment, userId))
+                    .toList();
+            response = responseFunction.apply(post, isAuthor, user.getName(), likeCount, postOnGoingStatus, imageList, null, postOfficialCommentResponses);
         } else if (board.getName().equals("제휴게시판") || board.getName().equals("공지사항게시판") || board.getName().equals("감사기구게시판")) {
-            response = responseFunction.apply(post, isAuthor, user.getName(), null, category.getName(), imageList, fileList);
+            response = responseFunction.apply(post, isAuthor, user.getName(), null, category.getName(), imageList, fileList,null);
         } else if (board.getName().equals("분실물게시판")) {
-            response = responseFunction.apply(post, isAuthor, user.getName(), null, category.getName(), imageList, null); //분실물 게시판은 파일첨부 제외
+            response = responseFunction.apply(post, isAuthor, user.getName(), null, category.getName(), imageList, null, null); //분실물 게시판은 파일첨부 제외
         }
 
         return PostDetailRes.of(response);

--- a/src/main/java/ussum/homepage/application/post/service/dto/response/postDetail/PetitionPostDetailResponse.java
+++ b/src/main/java/ussum/homepage/application/post/service/dto/response/postDetail/PetitionPostDetailResponse.java
@@ -2,6 +2,8 @@ package ussum.homepage.application.post.service.dto.response.postDetail;
 
 import lombok.Builder;
 import lombok.Getter;
+import ussum.homepage.application.comment.service.dto.response.PostCommentResponse;
+import ussum.homepage.application.comment.service.dto.response.PostOfficialCommentResponse;
 import ussum.homepage.domain.post.Post;
 import ussum.homepage.infra.jpa.post.entity.OngoingStatus;
 
@@ -12,17 +14,20 @@ public class PetitionPostDetailResponse extends PostDetailResDto {
     private final Integer likeCount;
     private final String onGoingStatus;
     private final List<String> imageList;
+    private final List<PostOfficialCommentResponse> officialCommentList;
 
     @Builder
     private PetitionPostDetailResponse(Long postId, String categoryName, String authorName, String title, String content, String createdAt, Boolean isAuthor,
-                                       Integer likeCount, String onGoingStatus, List<String> imageList) {
+                                       Integer likeCount, String onGoingStatus, List<String> imageList, List<PostOfficialCommentResponse> officialCommentList) {
         super(postId, categoryName, authorName, title, content, createdAt, isAuthor);
         this.likeCount = likeCount;
         this.onGoingStatus = onGoingStatus;
         this.imageList = imageList;
+        this.officialCommentList = officialCommentList;
     }
 
-    public static PetitionPostDetailResponse of(Post post, Boolean isAuthor, String authorName, Integer likeCount, String onGoingStatus, List<String> imageList) {
+    public static PetitionPostDetailResponse of(Post post, Boolean isAuthor, String authorName, Integer likeCount, String onGoingStatus, List<String> imageList,
+                                                List<PostOfficialCommentResponse> officialCommentList) {
         return PetitionPostDetailResponse.builder()
                 .postId(post.getId())
                 .categoryName(OngoingStatus.toKorean(onGoingStatus))
@@ -34,6 +39,7 @@ public class PetitionPostDetailResponse extends PostDetailResDto {
                 .likeCount(likeCount)
                 .onGoingStatus(onGoingStatus)
                 .imageList(imageList)
+                .officialCommentList(officialCommentList)
                 .build();
     }
 

--- a/src/main/java/ussum/homepage/domain/comment/PostCommentRepository.java
+++ b/src/main/java/ussum/homepage/domain/comment/PostCommentRepository.java
@@ -11,6 +11,7 @@ public interface PostCommentRepository {
     List<PostComment> findAllByPostId(Long postId);
     List<PostComment> findAllByPostIdOrderByLikesDesc(Long postId);
     List<PostComment> findAllByPostIdOrderByCreatedAtDesc(Long postId);
+    List<PostComment> findAllByPostIdAndCommentType(Long postId, String commentType);
     Optional<PostComment> findByPostIdAndUserId(Long postId, Long userId);
     Optional<PostComment> findById(Long id);
     PostComment save(PostComment postComment);

--- a/src/main/java/ussum/homepage/domain/comment/service/PostCommentFormatter.java
+++ b/src/main/java/ussum/homepage/domain/comment/service/PostCommentFormatter.java
@@ -7,5 +7,4 @@ import ussum.homepage.domain.comment.PostComment;
 public interface PostCommentFormatter {
     PostCommentResponse format(Long postId, Long userId, String commentType);
     PostCommentResponse format(PostComment postComment, Long userId);
-
 }

--- a/src/main/java/ussum/homepage/domain/comment/service/PostCommentReader.java
+++ b/src/main/java/ussum/homepage/domain/comment/service/PostCommentReader.java
@@ -55,12 +55,7 @@ public class PostCommentReader {
     }
 
     public List<PostComment> getCommentListWithPostIdAndCommentType(Long userId, Long postId, String commentType) {
-        List<PostComment> comments = postCommentRepository.findAllByPostIdAndCommentType(postId, commentType);
-        if (comments.isEmpty()) {
-            throw new PostCommentException(POST_COMMENT_NOT_FOUND);
-        }
-
-        return comments;
+        return postCommentRepository.findAllByPostIdAndCommentType(postId, commentType);
     }
 
 }

--- a/src/main/java/ussum/homepage/domain/comment/service/PostCommentReader.java
+++ b/src/main/java/ussum/homepage/domain/comment/service/PostCommentReader.java
@@ -6,8 +6,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import ussum.homepage.domain.comment.PostComment;
 import ussum.homepage.domain.comment.PostCommentRepository;
+import ussum.homepage.domain.comment.service.formatter.PostCommentFormatter;
 import ussum.homepage.domain.reaction.exception.PostCommentException;
-import ussum.homepage.domain.reaction.service.PostCommentReactionReader;
 import ussum.homepage.global.error.exception.InvalidValueException;
 
 import java.util.List;
@@ -51,7 +51,16 @@ public class PostCommentReader {
         if (comments.isEmpty()) {
             throw new PostCommentException(POST_COMMENT_NOT_FOUND);
         }
+        return comments;
+    }
+
+    public List<PostComment> getCommentListWithPostIdAndCommentType(Long userId, Long postId, String commentType) {
+        List<PostComment> comments = postCommentRepository.findAllByPostIdAndCommentType(postId, commentType);
+        if (comments.isEmpty()) {
+            throw new PostCommentException(POST_COMMENT_NOT_FOUND);
+        }
 
         return comments;
     }
+
 }

--- a/src/main/java/ussum/homepage/domain/comment/service/PostOfficialCommentFormatter.java
+++ b/src/main/java/ussum/homepage/domain/comment/service/PostOfficialCommentFormatter.java
@@ -1,0 +1,8 @@
+package ussum.homepage.domain.comment.service;
+
+import ussum.homepage.application.comment.service.dto.response.PostOfficialCommentResponse;
+import ussum.homepage.domain.comment.PostComment;
+
+public interface PostOfficialCommentFormatter {
+    PostOfficialCommentResponse format(PostComment postComment, Long userId);
+}

--- a/src/main/java/ussum/homepage/domain/comment/service/formatter/PostOfficialCommentFormatter.java
+++ b/src/main/java/ussum/homepage/domain/comment/service/formatter/PostOfficialCommentFormatter.java
@@ -1,0 +1,23 @@
+package ussum.homepage.domain.comment.service.formatter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import ussum.homepage.application.comment.service.dto.response.PostOfficialCommentResponse;
+import ussum.homepage.domain.comment.PostComment;
+import ussum.homepage.domain.user.User;
+import ussum.homepage.domain.user.service.UserReader;
+
+
+@Service
+@RequiredArgsConstructor
+public class PostOfficialCommentFormatter implements ussum.homepage.domain.comment.service.PostOfficialCommentFormatter {
+    private final UserReader userReader;
+
+    @Override
+    public PostOfficialCommentResponse format(PostComment postComment, Long userId) {
+        User user = userReader.getUserWithId(postComment.getUserId());
+        Boolean isAuthor = userId != null && userId.equals(postComment.getUserId());
+
+        return PostOfficialCommentResponse.of(postComment, user.getName(), postComment.getCommentType(), isAuthor);
+    }
+}

--- a/src/main/java/ussum/homepage/domain/post/service/PostStatusProcessor.java
+++ b/src/main/java/ussum/homepage/domain/post/service/PostStatusProcessor.java
@@ -45,20 +45,24 @@ public class PostStatusProcessor {
     }
 
     /**
-     * '진행중' 청원일 때 30일이내에 좋아요 100개를 달성하지 못하면 '종료됨'
-     * '진행중' 청원일 때 30일이내에 좋아요 100개를 달성하면 '접수된' 청원으로 변경
+     * '진행중' 청원일 때 30일이 지난 시점에 좋아요 100개를 달성하지 못하면 '종료됨'
+     * '진행중' 청원일 때 30일이 지난 시점에 좋아요 100개를 달성하면 '접수된' 청원으로 변경
      */
     private String handleInProgressStatus(Post post, Integer likeCountOfPost) {
         LocalDateTime createdAt = LocalDateTime.parse(post.getCreatedAt());
-        if (LocalDateTime.now().isBefore(createdAt.plusDays(30))) {
-            // 30일 이내에 좋아요 100개를 달성하지 못한 경우
+        // 30일이 경과한 경우
+        if (LocalDateTime.now().isAfter(createdAt.plusDays(30))) {
+            // 30일 동안 좋아요 100개를 달성하지 못한 경우에만 종료됨 상태로 변경
             if (likeCountOfPost < 100) {
                 return updatePostOngoingStatus(post.getId(), "COMPLETED");
-            } else {
+            } else return updatePostOngoingStatus(post.getId(), "RECEIVED");
+        } else {
+            if (likeCountOfPost >= 100) {
                 return updatePostOngoingStatus(post.getId(), "RECEIVED");
-            }
+            } else return "IN_PROGRESS";
         }
-        return "IN_PROGRESS";
+        // 30일 이내면 아직 상태를 변경하지 않음
+//        return "IN_PROGRESS";
     }
 
     /**

--- a/src/main/java/ussum/homepage/domain/post/service/formatter/PostDetailFunction.java
+++ b/src/main/java/ussum/homepage/domain/post/service/formatter/PostDetailFunction.java
@@ -3,7 +3,7 @@ package ussum.homepage.domain.post.service.formatter;
 import java.util.List;
 
 @FunctionalInterface
-public interface PostDetailFunction<T, K, U, V, W, Q, Y, R> {
-    R apply(T t, K k, U u, V v, W w, List<Q> q, List<Y> y);
+public interface PostDetailFunction<T, K, U, V, W, Q, Y, I, R> {
+    R apply(T t, K k, U u, V v, W w, List<Q> q, List<Y> y, List<I> i);
 }
 

--- a/src/main/java/ussum/homepage/global/config/SecurityConfig.java
+++ b/src/main/java/ussum/homepage/global/config/SecurityConfig.java
@@ -31,10 +31,10 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",
-//            "/board/{boardCode}/posts/{postId}",
-//            "/board/posts/{postId}/comments"
-    };
+            "/board/{boardCode}/posts/{postId}",
+            "/board/posts/{postId}/comments"
 
+    };
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/ussum/homepage/global/config/SecurityConfig.java
+++ b/src/main/java/ussum/homepage/global/config/SecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import ussum.homepage.global.config.CorsConfig;
 import ussum.homepage.global.config.auth.ExceptionHandlerFilter;
 import ussum.homepage.global.jwt.*;
 
@@ -33,8 +31,8 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",
-            "/board/{boardCode}/posts/{postId}",
-            "/board/posts/{postId}/comments"
+//            "/board/{boardCode}/posts/{postId}",
+//            "/board/posts/{postId}/comments"
     };
 
 

--- a/src/main/java/ussum/homepage/infra/jpa/post/BoardRepositoryImpl.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/BoardRepositoryImpl.java
@@ -24,7 +24,6 @@ public class BoardRepositoryImpl implements BoardRepository {
     }
     @Override
     public Optional<Board> findByBoardCode(String boardCode){
-        System.out.println("boardCode = " + boardCode);
         return boardJpaRepository.findByBoardCode(BoardCode.getEnumBoardCodeFromStringBoardCode(boardCode)).map(boardMapper::toDomain);
     }
     @Override


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 청원게시물 단건 조회 시 청원게시물 내용,댓글 반환 dto 부분에 공식답변 dto 포함
  - PostOfficialCommentFormatter 하나 만들어서 dto처리 하였음(나중에 수정해도 상관X)
  - 기존 댓글 전체 조회 api에도 공식답변 조회되는거 일단 삭제 안함
- 게시물 조회 경로(비로그인도 가능) SecurityConfig에 추가한 이후 파일생성 경로랑 겹치는지 파일생성 api가 동작을 안함
  - 그래서 일단 파일생성 경로 /board/{boardCode}/files 로 변경(이러면 오류 안남) -> 원인 불분명 

---

### ✏️ 관련 이슈(선택 사항)
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #52 

---

### 코드 리뷰 받고 싶은 부분



---




