### PR TITLE
[refactor] #55 메일 문의시 바로 회신가능하게 수정

### DIFF
--- a/src/main/java/ussum/homepage/application/user/controller/OnBoardingController.java
+++ b/src/main/java/ussum/homepage/application/user/controller/OnBoardingController.java
@@ -26,7 +26,8 @@ public class OnBoardingController {
     }
 
     @PostMapping("/mail")
-    public ResponseEntity<ApiResponse<?>> sendEmail(@RequestBody OnBoardingEmailRequest onBoardingEmailRequest) {
+    public ResponseEntity<ApiResponse<?>> sendEmail(@UserId Long userId,
+                                                    @RequestBody OnBoardingEmailRequest onBoardingEmailRequest) {
         onBoardingService.sendEmail(onBoardingEmailRequest);
         return ApiResponse.success(null);
     }

--- a/src/main/java/ussum/homepage/application/user/service/OnBoardingService.java
+++ b/src/main/java/ussum/homepage/application/user/service/OnBoardingService.java
@@ -54,9 +54,11 @@ public class OnBoardingService {
             MimeMessage mimeMessage = javaMailSender.createMimeMessage();
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage);
             mimeMessageHelper.setTo(SENDER_EMAIL_ADDRESS);
-            mimeMessageHelper.setFrom(onBoardingEmailRequest.email());
-            mimeMessageHelper.setSubject(onBoardingEmailRequest.toString(onBoardingEmailRequest));
-            mimeMessageHelper.setText(onBoardingEmailRequest.content());
+            mimeMessageHelper.setFrom(SENDER_EMAIL_ADDRESS);
+            mimeMessageHelper.setReplyTo(onBoardingEmailRequest.email());
+//            mimeMessageHelper.setFrom(onBoardingEmailRequest.email());
+            mimeMessageHelper.setSubject(onBoardingEmailRequest.toEmailSubject());
+            mimeMessageHelper.setText(onBoardingEmailRequest.toEmailContent());
 
             javaMailSender.send(mimeMessage);
         } catch (MessagingException | OnBoardingMessagingException onBoardingMessagingException) {

--- a/src/main/java/ussum/homepage/application/user/service/dto/request/OnBoardingEmailRequest.java
+++ b/src/main/java/ussum/homepage/application/user/service/dto/request/OnBoardingEmailRequest.java
@@ -7,10 +7,14 @@ public record OnBoardingEmailRequest(
         String email,
         String content
 ) {
-    public String toString(OnBoardingEmailRequest onBoardingEmailRequest) {
-        return onBoardingEmailRequest.studentId + "학번과 "
-                + onBoardingEmailRequest.email + " 라는 이메일을 가진 "
-                + onBoardingEmailRequest.name + "님이 "
-                + "메일을 보냈습니다.";
+    public String toEmailSubject() {
+        return "[총학생회 홈페이지 학생인증 문의] " + name;
+    }
+
+    public String toEmailContent() {
+        return "학생명 : " + name + "\n" +
+                "학번 : " + studentId + "\n" +
+                "이메일 : " + email + "\n" +
+                "문의 내용 : " + content;
     }
 }


### PR DESCRIPTION
다른 "From" 주소를 설정하려 해도, Gmail 서버는 이를 무시하고 인증된 이메일 주소를 발신자 주소로 사용하기 때문에 실제 구글 메일함 들어가면 '나'에게 보낸 메일처럼 나타냄

### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 메일 문의시 바로 사용자가 입력한 메일로 회신가능하게 수정 -> mimeMessageHelper.setReplyTo()
  - 다른 "From" 주소를 설정하려 해도, Gmail 서버는 이를 무시하고 인증된 이메일 주소를 발신자 주소로 사용하기 때문에 실제 구글 메일함 들어가면 '나'에게 보낸 메일처럼 나타내어 짐

---

### ✏️ 관련 이슈(선택 사항)
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Ref : #55 

---

### 코드 리뷰 받고 싶은 부분



---




