### PR TITLE
[refactor] #75 청원게시물 전체 조회 시 진행상태 변경 로직 추가

### DIFF
--- a/src/main/java/ussum/homepage/application/post/service/PostManageService.java
+++ b/src/main/java/ussum/homepage/application/post/service/PostManageService.java
@@ -24,7 +24,6 @@ import ussum.homepage.domain.comment.PostComment;
 import ussum.homepage.domain.comment.service.PostCommentReader;
 import ussum.homepage.domain.comment.service.PostOfficialCommentFormatter;
 
-import ussum.homepage.domain.group.service.GroupReader;
 import ussum.homepage.domain.member.Member;
 import ussum.homepage.domain.member.service.MemberReader;
 import ussum.homepage.domain.post.Board;
@@ -62,7 +61,6 @@ public class PostManageService {
     private final PostReactionReader postReactionReader;
     private final UserReader userReader;
     private final MemberReader memberReader;
-    private final GroupReader groupReader;
     private final PostCommentReader postCommentReader;
     private final PostFileReader postFileReader;
     private final PostAppender postAppender;
@@ -91,6 +89,7 @@ public class PostManageService {
     );
 
 
+    @Transactional
     public PostListRes<?> getPostList(int page, int take, String boardCode, String groupCode, String memberCode, String category) {
         Board board = boardReader.getBoardWithBoardCode(boardCode);
 //        Pageable pageable = PageInfo.of(page, take);
@@ -135,7 +134,8 @@ public class PostManageService {
                             return responseFunction.apply(post, null, null);
                         case "청원게시판":
                             likeCount = postReactionReader.countPostReactionsByType(post.getId(), "like");
-                            return responseFunction.apply(post, likeCount, null);
+                            Post updatedPost = postStatusProcessor.processStatus(post);
+                            return responseFunction.apply(updatedPost, likeCount, null);
                         default:
                             throw new EntityNotFoundException(String.valueOf(POST_NOT_FOUND));
                     }
@@ -180,12 +180,12 @@ public class PostManageService {
         PostDetailResDto response = null;
         if (board.getName().equals("청원게시판")) {
             Integer likeCount = postReactionReader.countPostReactionsByType(post.getId(), "like");
-            String postOnGoingStatus = postStatusProcessor.processStatus(post);
+            Post updatedPost = postStatusProcessor.processStatus(post);
             List<PostComment> officialPostComments = postCommentReader.getCommentListWithPostIdAndCommentType(userId, postId, "OFFICIAL");
             List<PostOfficialCommentResponse> postOfficialCommentResponses = officialPostComments.stream()
                     .map(postOfficialComment -> postOfficialCommentFormatter.format(postOfficialComment, userId))
                     .toList();
-            response = responseFunction.apply(post, isAuthor, user.getName(), likeCount, postOnGoingStatus, imageList, null, postOfficialCommentResponses);
+            response = responseFunction.apply(updatedPost, isAuthor, user.getName(), likeCount, updatedPost.getOnGoingStatus(), imageList, null, postOfficialCommentResponses);
         } else if (board.getName().equals("제휴게시판") || board.getName().equals("공지사항게시판") || board.getName().equals("감사기구게시판")) {
             response = responseFunction.apply(post, isAuthor, user.getName(), null, post.getCategory(), imageList, fileList,null);
         } else if (board.getName().equals("분실물게시판")) {

--- a/src/main/java/ussum/homepage/domain/post/service/PostStatusProcessor.java
+++ b/src/main/java/ussum/homepage/domain/post/service/PostStatusProcessor.java
@@ -2,6 +2,7 @@ package ussum.homepage.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ussum.homepage.domain.comment.service.PostCommentReader;
 import ussum.homepage.domain.member.service.MemberManager;
 import ussum.homepage.domain.post.Post;
@@ -24,7 +25,7 @@ public class PostStatusProcessor {
     private final PostReactionReader postReactionReader;
     private final MemberManager memberManager;
 
-    public String processStatus(Post post) {
+    public Post processStatus(Post post) {
         //현재 게시물 상태 checking
         String currentStatus = Optional.ofNullable(post.getOnGoingStatus())
                 .orElseThrow(() -> new PostException(POST_ONGOING_STATUS_IS_NOT_UPDATED));
@@ -32,37 +33,36 @@ public class PostStatusProcessor {
         Integer likeCountOfPost = postReactionReader.countPostReactionsByType(post.getId(), "like");
         switch (currentStatus) {
             case "진행중":
-                return handleInProgressStatus(post,likeCountOfPost);
+                return handleInProgressStatus(post, likeCountOfPost);
             case "접수완료":
                 return handleReceivedStatus(post);
         }
-        return currentStatus;
+        return post;
     }
 
     /**
      * 해당 로직은 실제 청원게시물의 OnGoingStatus를 변경하는 로직
      */
-    public String updatePostOngoingStatus(Long postId, String onGoingStatus) {
-        return postRepository.updatePostOngoingStatus(postId, onGoingStatus, Category.getEnumCategoryCodeFromStringCategoryCode(onGoingStatus)).getOnGoingStatus();
+    public Post updatePostCategoryAndOngoingStatus(Long postId, String onGoingStatus) {
+        return postRepository.updatePostOngoingStatus(postId, onGoingStatus, Category.getEnumCategoryCodeFromStringCategoryCode(onGoingStatus));
     }
 
     /**
      * '진행중' 청원일 때 30일이 지난 시점에 좋아요 100개를 달성하지 못하면 '종료됨'
      * '진행중' 청원일 때 30일이 지난 시점에 좋아요 100개를 달성하면 '접수된' 청원으로 변경
      */
-    private String handleInProgressStatus(Post post, Integer likeCountOfPost) {
-//        LocalDateTime createdAt = LocalDateTime.parse(post.getCreatedAt());
+    private Post handleInProgressStatus(Post post, Integer likeCountOfPost) {
         LocalDateTime createdAt = DateUtils.parseHourMinSecFromCustomString(post.getCreatedAt());
         // 30일이 경과한 경우
         if (LocalDateTime.now().isAfter(createdAt.plusDays(30))) {
             // 30일 동안 좋아요 100개를 달성하지 못한 경우에만 종료됨 상태로 변경
             if (likeCountOfPost < 100) {
-                return updatePostOngoingStatus(post.getId(), "종료됨");
-            } else return updatePostOngoingStatus(post.getId(), "접수완료");
+                return updatePostCategoryAndOngoingStatus(post.getId(), "종료됨");
+            } else return updatePostCategoryAndOngoingStatus(post.getId(), "접수완료");
         } else {
             if (likeCountOfPost >= 100) {
-                return updatePostOngoingStatus(post.getId(), "접수완료");
-            } else return "진행중";
+                return updatePostCategoryAndOngoingStatus(post.getId(), "접수완료");
+            } else return post;
         }
         // 30일 이내면 아직 상태를 변경하지 않음
 //        return "IN_PROGRESS";
@@ -71,11 +71,11 @@ public class PostStatusProcessor {
     /**
      * '접수된' 청원에서 관리자가 댓글을 달면 '답변완료' 청원으로 변경
      */
-    private String handleReceivedStatus(Post post) {
+    private Post handleReceivedStatus(Post post) {
         if (isAnsweredByAdmin(post)) {
-            return updatePostOngoingStatus(post.getId(),"답변완료");
+            return updatePostCategoryAndOngoingStatus(post.getId(),"답변완료");
         }
-        return "접수완료";
+        return post;
     }
 
     /**

--- a/src/main/java/ussum/homepage/infra/jpa/post/PostMapper.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/PostMapper.java
@@ -11,14 +11,11 @@ import ussum.homepage.infra.utils.DateUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Component
 public class PostMapper {
     public Post toDomain(PostEntity postEntity){
-        String onGoingStatus = Optional.ofNullable(postEntity.getOngoingStatus())
-                .map(OngoingStatus::getStringOnGoingStatus)
-                .orElse(null);
+        String onGoingStatus = OngoingStatus.fromEnumOrNull(postEntity.getOngoingStatus());
 
         return Post.of(
                 postEntity.getId(),
@@ -39,11 +36,6 @@ public class PostMapper {
 
     public PostEntity toEntity(Post post, UserEntity user, BoardEntity board) {
         LocalDateTime lastEditedAt = DateUtils.parseHourMinSecFromCustomString(post.getLastEditedAt());
-
-//        OngoingStatus ongoingStatus = Optional.ofNullable(post.getOnGoingStatus())
-//                .map(OngoingStatus::getEnumOngoingStatusFromStringOngoingStatus)
-//                .orElse(null);
-
         OngoingStatus ongoingStatus = OngoingStatus.fromStringOrNull(post.getOnGoingStatus());
 
         return PostEntity.of(

--- a/src/main/java/ussum/homepage/infra/jpa/post/entity/OngoingStatus.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/entity/OngoingStatus.java
@@ -43,4 +43,10 @@ public enum OngoingStatus {
         return fromString(stringOnGoingStatus).orElse(null);
     }
 
+    public static String fromEnumOrNull(OngoingStatus ongoingStatus) {
+        return Optional.ofNullable(ongoingStatus)
+                .map(OngoingStatus::getStringOnGoingStatus)
+                .orElse(null);
+    }
+
 }

--- a/src/main/java/ussum/homepage/infra/jpa/post/entity/PostEntity.java
+++ b/src/main/java/ussum/homepage/infra/jpa/post/entity/PostEntity.java
@@ -39,7 +39,6 @@ public class PostEntity extends BaseEntity {
     @JoinColumn(name = "board_id")
     private BoardEntity boardEntity;
 
-
     public static PostEntity from(Long id){
         return new PostEntity(id, null, null, null, null, null, null, null, null, null, null);
     }
@@ -58,6 +57,7 @@ public class PostEntity extends BaseEntity {
     }
 
     public void updateStatusAndCategoryCode(OngoingStatus newStatus) {
+        this.category = Category.getEnumCategoryCodeFromStringCategoryCode(newStatus.getStringOnGoingStatus());
         this.ongoingStatus = newStatus;
     }
 }


### PR DESCRIPTION
PostStatusProcessor의 processStatus메소드의 반환값을 String이 아닌 Post 도매인 객체로 변경

### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 청원게시물 전체 조회 시 진행 상태 변경도 조회 할 때마다 상태가 변경 혹은 반영되야 하기 때문에 PostStatusProcessor의 processStatus의 반환 값을 Post 도메인 객체로 반환하게 하고 이를 getPostList 메소드안에 호출하여 상태 체크가 한번 진행된 updatedPost를 인자로 전달하게 변경
- 근데 조회를 담당하는 getPostList메소드에 청원게시물일 때 진행상태를 체크하고 변경을 해줄 경우가 있는데 현재는@Transactional(readOnly = true)가 적용되어 있어서 이 클래스 내의 모든 메서드는 기본적으로 읽기 전용 트랜잭션으로 실행됨. getPostList에서 호출하는 processStatus의 로직이 한번 돌고 디비에 상태 변경된 것이 하나의 트랜잭션으로 간주될 필요가 있기 때문에 트랜잭션의 범위를 processStatus에서 끊어버리면 processStatus 메서드에서의 트랜잭션은 독립적인 영속성 컨텍스트를 사용하기 때문에 processStatus에서 발생한 변경 사항은 getPostList의 나머지 코드에 공유되지 않을 수 있다. 그래서 getPostList메소드에 @Transactional을 걸어야 한다고 생각.

---

### ✏️ 관련 이슈(선택 사항)
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #75 

---

### 코드 리뷰 받고 싶은 부분



---




