### PR TITLE
[refactor] #91 게시물 단건 조회, 댓글 전체 조회 비로그인 로그인 모두 허용하는 로직 수정 

### DIFF
--- a/src/main/java/ussum/homepage/application/comment/controller/CommentController.java
+++ b/src/main/java/ussum/homepage/application/comment/controller/CommentController.java
@@ -50,12 +50,11 @@ public class CommentController {
             요청 url 상에 postId 와 commentId를 받습니다. 즉, 게시물 id와 댓글 id를 받습니다.
             PostCommentUpdateRequest 요청 json에 content 필드를 이용하여 댓글 내용을 작성합니다.
             """)
-    @PatchMapping("/posts/{postId}/comments/{commentId}")
+    @PatchMapping("/posts/comments/{commentId}")
     public ResponseEntity<ApiResponse<?>> editPostComment(@Parameter(hidden = true) @UserId Long userId,
-                                                          @PathVariable(name = "postId") Long postId,
                                                           @PathVariable(name = "commentId") Long commentId,
                                                           @RequestBody PostCommentUpdateRequest postCommentUpdateRequest) {
-        commentService.editComment(userId, postId, commentId, postCommentUpdateRequest);
+        commentService.editComment(userId, commentId, postCommentUpdateRequest);
         return ApiResponse.success(null);
     }
 

--- a/src/main/java/ussum/homepage/application/comment/controller/PostCommentManagerController.java
+++ b/src/main/java/ussum/homepage/application/comment/controller/PostCommentManagerController.java
@@ -1,6 +1,7 @@
 package ussum.homepage.application.comment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import ussum.homepage.application.comment.service.PostCommentManageService;
 import ussum.homepage.application.post.service.dto.request.PostUserRequest;
 import ussum.homepage.global.ApiResponse;
+import ussum.homepage.global.config.auth.UserId;
 
 @RequiredArgsConstructor
 @RequestMapping("/board")
@@ -27,7 +29,7 @@ public class PostCommentManagerController {
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<?>> getPostCommentList(@PathVariable Long postId,
                                                              @RequestParam(name = "type") String type,
-                                                             @RequestParam Long userId) { //type은 "인기순" 인지 "최신순"인지
+                                                             @Parameter(hidden = true) @UserId Long userId) { //type은 "인기순" 인지 "최신순"인지
         return ApiResponse.success(postCommentManageService.getCommentList(postId, type, userId));
     }
 }

--- a/src/main/java/ussum/homepage/application/comment/controller/PostReplyCommentController.java
+++ b/src/main/java/ussum/homepage/application/comment/controller/PostReplyCommentController.java
@@ -38,12 +38,11 @@ public class PostReplyCommentController {
             요청 url 상에 commentId 와 reply-commentId를 받습니다. 즉, 댓글 id와 대댓글 id를 받습니다.
             PostReplyCommentUpdateRequest 요청 json에 content 필드를 이용하여 댓글 내용을 작성합니다.
             """)
-    @PatchMapping("/posts/comments/{commentId}/reply-comments/{reply-commentId}")
+    @PatchMapping("/posts/comments/reply-comments/{reply-commentId}")
     public ResponseEntity<ApiResponse<?>> editPostReplyComment(@Parameter(hidden = true) @UserId Long userId,
-                                                               @PathVariable(name = "commentId") Long commentId,
                                                                @PathVariable(name = "reply-commentId") Long replyCommentId,
                                                                @RequestBody PostReplyCommentUpdateRequest postReplyCommentUpdateRequest) {
-        postReplyCommentService.editReplyComment(userId, commentId, replyCommentId, postReplyCommentUpdateRequest);
+        postReplyCommentService.editReplyComment(userId, replyCommentId, postReplyCommentUpdateRequest);
         return ApiResponse.success(null);
     }
 

--- a/src/main/java/ussum/homepage/application/comment/service/CommentService.java
+++ b/src/main/java/ussum/homepage/application/comment/service/CommentService.java
@@ -43,9 +43,9 @@ public class CommentService {
     }
 
     @Transactional
-    public PostCommentResponse editComment(Long userId, Long postId, Long commentId, PostCommentUpdateRequest postCommentUpdateRequest){
+    public PostCommentResponse editComment(Long userId, Long commentId, PostCommentUpdateRequest postCommentUpdateRequest){
         PostComment postComment = postCommentReader.getPostComment(commentId);
-        PostComment editedPostComment = postCommentModifier.updateComment(postComment, userId, postId, commentId, postCommentUpdateRequest);
+        PostComment editedPostComment = postCommentModifier.updateComment(postComment, userId, commentId, postCommentUpdateRequest);
 //        PostComment postComment = postCommentModifier.updateComment(userId, postId, commentId, , postCommentUpdateRequest);
 //        return postCommentFormatter.format(postComment.getPostId(), postComment.getUserId(), postComment.getCommentType());
         return postCommentFormatter.format(editedPostComment, userId);

--- a/src/main/java/ussum/homepage/application/comment/service/PostReplyCommentService.java
+++ b/src/main/java/ussum/homepage/application/comment/service/PostReplyCommentService.java
@@ -27,9 +27,9 @@ public class PostReplyCommentService {
     }
 
     @Transactional
-    public PostReplyCommentResponse editReplyComment(Long userId, Long commentId, Long replyCommentId, PostReplyCommentUpdateRequest postReplyCommentUpdateRequest) {
+    public PostReplyCommentResponse editReplyComment(Long userId, Long replyCommentId, PostReplyCommentUpdateRequest postReplyCommentUpdateRequest) {
         PostReplyComment postReplyComment = postReplyCommentReader.getPostReplyComment(replyCommentId);
-        return postReplyCommentFormatter.format(postReplyCommentModifier.updatePostReplyComment(postReplyComment, userId, commentId, postReplyCommentUpdateRequest), userId);
+        return postReplyCommentFormatter.format(postReplyCommentModifier.updatePostReplyComment(postReplyComment, userId, postReplyCommentUpdateRequest), userId);
     }
 
     @Transactional

--- a/src/main/java/ussum/homepage/application/comment/service/dto/request/PostCommentUpdateRequest.java
+++ b/src/main/java/ussum/homepage/application/comment/service/dto/request/PostCommentUpdateRequest.java
@@ -8,11 +8,11 @@ import java.time.LocalDateTime;
 public record PostCommentUpdateRequest(
         String content
 ) {
-    public PostComment toDomain(PostComment postComment, Long commentId, Long postId, Long userId) {
+    public PostComment toDomain(PostComment postComment, Long commentId, Long userId) {
         return PostComment.of(
                 commentId,
                 content,
-                postId,
+                postComment.getPostId(),
                 userId,
                 postComment.getCommentType(),
                 DateUtils.parseHourMinSecFromCustomString(postComment.getCreatedAt()),

--- a/src/main/java/ussum/homepage/application/comment/service/dto/request/PostReplyCommentUpdateRequest.java
+++ b/src/main/java/ussum/homepage/application/comment/service/dto/request/PostReplyCommentUpdateRequest.java
@@ -8,11 +8,11 @@ import java.time.LocalDateTime;
 public record PostReplyCommentUpdateRequest(
         String content
 ) {
-    public PostReplyComment toDomain(PostReplyComment postReplyComment, Long userId, Long commentId) {
+    public PostReplyComment toDomain(PostReplyComment postReplyComment, Long userId) {
         return PostReplyComment.of(
                 postReplyComment.getId(),
                 content,
-                commentId,
+                postReplyComment.getCommentId(),
                 userId,
                 DateUtils.parseHourMinSecFromCustomString(postReplyComment.getCreatedAt()),
                 LocalDateTime.now(),

--- a/src/main/java/ussum/homepage/application/post/controller/PostManageController.java
+++ b/src/main/java/ussum/homepage/application/post/controller/PostManageController.java
@@ -48,7 +48,7 @@ public class PostManageController {
             """)
     @GetMapping("data/posts")
     public ResponseEntity<ApiResponse<?>> getDataPostsList(@RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "take") int take,
-                                                            @RequestParam(name = "majorCategory", required = false) String majorCategory, @RequestParam(name = "middleCategory", required = false) String middleCategory,@RequestParam(name = "subCategory", required = false) String subCategory) {
+                                                           @RequestParam(name = "majorCategory", required = false) String majorCategory, @RequestParam(name = "middleCategory", required = false) String middleCategory,@RequestParam(name = "subCategory", required = false) String subCategory) {
 
 //        PostListResponse postList = postService.getPostList(PageRequest.of(page, take, Sort.by("id").descending()), boardCode);
         return ApiResponse.success(postManageService.getDataList(page, take, majorCategory, middleCategory, subCategory));
@@ -67,7 +67,7 @@ public class PostManageController {
     @GetMapping("/{boardCode}/posts/{postId}")
     public ResponseEntity<ApiResponse<?>> getBoardPost(@PathVariable(name = "boardCode") String boardCode,
                                                        @PathVariable(name = "postId") Long postId,
-                                                       @RequestParam(required = false) Long userId) {
+                                                       @Parameter(hidden = true) @UserId Long userId) {
         return ApiResponse.success(postManageService.getPost(userId, boardCode, postId));
     }
 

--- a/src/main/java/ussum/homepage/domain/comment/service/PostCommentModifier.java
+++ b/src/main/java/ussum/homepage/domain/comment/service/PostCommentModifier.java
@@ -15,8 +15,8 @@ public class PostCommentModifier {
 //    public PostComment updateComment(Long userId, Long postId, Long commentId, String commentType, PostCommentUpdateRequest postCommentUpdateRequest) {
 //        return postCommentRepository.update(postCommentUpdateRequest.toDomain(commentId, postId, userId, commentType));
 //    }
-    public PostComment updateComment(PostComment postComment, Long userId, Long postId, Long commentId, PostCommentUpdateRequest postCommentUpdateRequest) {
-        return postCommentRepository.update(postCommentUpdateRequest.toDomain(postComment, commentId, postId, userId));
+    public PostComment updateComment(PostComment postComment, Long userId, Long commentId, PostCommentUpdateRequest postCommentUpdateRequest) {
+        return postCommentRepository.update(postCommentUpdateRequest.toDomain(postComment, commentId, userId));
     }
     public void deleteComment(Long commentId){
         postCommentRepository.delete(postCommentReader.getPostComment(commentId));

--- a/src/main/java/ussum/homepage/domain/comment/service/PostReplyCommentModifier.java
+++ b/src/main/java/ussum/homepage/domain/comment/service/PostReplyCommentModifier.java
@@ -12,8 +12,8 @@ public class PostReplyCommentModifier {
     private final PostReplyCommentRepository postReplyCommentRepository;
     private final PostReplyCommentReader postReplyCommentReader;
 
-    public PostReplyComment updatePostReplyComment(PostReplyComment postReplyComment, Long userId, Long commentId, PostReplyCommentUpdateRequest postReplyCommentUpdateRequest) {
-        return postReplyCommentRepository.update(postReplyCommentUpdateRequest.toDomain(postReplyComment, userId, commentId));
+    public PostReplyComment updatePostReplyComment(PostReplyComment postReplyComment, Long userId, PostReplyCommentUpdateRequest postReplyCommentUpdateRequest) {
+        return postReplyCommentRepository.update(postReplyCommentUpdateRequest.toDomain(postReplyComment, userId));
     }
 
     public void deletePostReplyComment(Long replyCommentId) {

--- a/src/main/java/ussum/homepage/global/config/SecurityConfig.java
+++ b/src/main/java/ussum/homepage/global/config/SecurityConfig.java
@@ -20,6 +20,62 @@ import ussum.homepage.global.jwt.*;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+//    private final CorsConfig corsConfig;
+//    private final JwtTokenProvider provider;
+//    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+//    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+//
+//    private static final String[] getWhiteList = {
+//            "/board/{boardCode}/posts",
+//            "/board/{boardCode}/posts/{postId}",
+//            "/board/posts/{postId}/comments",
+//            "/board/{boardCode}/{groupCode}/{memberCode}/posts",
+//            "/board/data/posts",
+//            "/board/{boardCode}/posts/top-liked"
+//    };
+//
+//    private static final String[] whiteList = {
+//            "/auth/**",
+//            "/swagger-ui/**",
+//            "/swagger-resources/**",
+//            "/v3/api-docs/**",
+//            "/admin/**",
+//            "/onboarding/mail"
+//    };
+//
+//    @Bean
+//    public PasswordEncoder passwordEncoder() {
+//        return new BCryptPasswordEncoder();
+//    }
+//
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer() {
+//        return web -> web.ignoring()
+//                .requestMatchers(HttpMethod.GET, getWhiteList)
+//                .requestMatchers(whiteList);
+//    }
+//
+//    @Bean
+//    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//        return http
+//                .formLogin(AbstractHttpConfigurer::disable)
+//                .httpBasic(AbstractHttpConfigurer::disable)
+//                .csrf(AbstractHttpConfigurer::disable)
+//                .sessionManagement(sessionManagementConfigurer ->
+//                        sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+//                .exceptionHandling(exceptionHandlingConfigurer ->
+//                        exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+//                .exceptionHandling(exceptionHandlingConfigurer ->
+//                        exceptionHandlingConfigurer.accessDeniedHandler(jwtAccessDeniedHandler))
+//                .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+//                        authorizationManagerRequestMatcherRegistry.anyRequest().authenticated()) // 일단 추가
+//                .addFilter(corsConfig.corsFilter())
+//                .addFilterBefore(new JwtFilter(provider), UsernamePasswordAuthenticationFilter.class)
+//                .addFilterBefore(new ExceptionHandlerFilter(), JwtFilter.class)
+//                .build();
+//    }
+//}
+
     private final CorsConfig corsConfig;
     private final JwtTokenProvider provider;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
@@ -27,11 +83,15 @@ public class SecurityConfig {
 
     private static final String[] getWhiteList = {
             "/board/{boardCode}/posts",
-            "/board/{boardCode}/posts/{postId}",
-            "/board/posts/{postId}/comments",
             "/board/{boardCode}/{groupCode}/{memberCode}/posts",
             "/board/data/posts",
-            "/boards/{boardCode}/posts/top-liked"
+            "/board/{boardCode}/posts/top-liked",
+            "/board//{boardCode}/posts/search"
+    };
+
+    private static final String[] bothWhiteList = {
+            "/board/{boardCode}/posts/{postId}",
+            "/board/posts/{postId}/comments"
     };
 
     private static final String[] whiteList = {
@@ -50,6 +110,7 @@ public class SecurityConfig {
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
+        //Security Filter Chain을 거치지 않음
         return web -> web.ignoring()
                 .requestMatchers(HttpMethod.GET, getWhiteList)
                 .requestMatchers(whiteList);
@@ -68,7 +129,9 @@ public class SecurityConfig {
                 .exceptionHandling(exceptionHandlingConfigurer ->
                         exceptionHandlingConfigurer.accessDeniedHandler(jwtAccessDeniedHandler))
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                        authorizationManagerRequestMatcherRegistry.anyRequest().authenticated()) // 일단 추가
+                        authorizationManagerRequestMatcherRegistry
+                                .requestMatchers(HttpMethod.GET, bothWhiteList).permitAll() // botWhiteList에 포함된 경로에 대해서만 토큰 없어도 혹은 있어도 접근 허용
+                                .anyRequest().authenticated()) // 나머지 요청은 인증 필요
                 .addFilter(corsConfig.corsFilter())
                 .addFilterBefore(new JwtFilter(provider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtFilter.class)

--- a/src/main/java/ussum/homepage/global/config/auth/UserIdArgumentResolver.java
+++ b/src/main/java/ussum/homepage/global/config/auth/UserIdArgumentResolver.java
@@ -1,6 +1,7 @@
 package ussum.homepage.global.config.auth;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -19,8 +20,13 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        return SecurityContextHolder.getContext()
-                .getAuthentication()
-                .getPrincipal();
+//        return SecurityContextHolder.getContext()
+//                .getAuthentication()
+//                .getPrincipal();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || "anonymousUser".equals(authentication.getPrincipal())) {
+            return null; // 비로그인 사용자일 경우 null 반환
+        }
+        return authentication.getPrincipal();
     }
 }

--- a/src/main/java/ussum/homepage/global/jwt/JwtFilter.java
+++ b/src/main/java/ussum/homepage/global/jwt/JwtFilter.java
@@ -2,6 +2,7 @@ package ussum.homepage.global.jwt;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -9,15 +10,47 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.filter.OncePerRequestFilter;
 import ussum.homepage.global.error.exception.UnauthorizedException;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import static ussum.homepage.global.error.status.ErrorStatus.INVALID_ACCESS_TOKEN;
-
+import static ussum.homepage.global.error.status.ErrorStatus.INVALID_ACCESS_TOKEN_VALUE;
+//
+//@RequiredArgsConstructor
+//public class JwtFilter extends OncePerRequestFilter {
+//    private static final String HEADER = "Authorization";
+//    private static final String TOKEN_PREFIX = "Bearer ";
+//    private final JwtTokenProvider provider;
+//
+//    @Override
+//    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+//        String accessToken = getAccessTokenFromRequest(request);
+//        provider.validateAccessToken(accessToken); // 예외 발생 가능
+//        Long userId = provider.getSubject(accessToken);
+//
+//        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, null);
+//        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+//        SecurityContextHolder.getContext().setAuthentication(authentication);
+//
+//        filterChain.doFilter(request, response);
+//    }
+//
+//    private String getAccessTokenFromRequest(HttpServletRequest request) {
+//        String accessToken = request.getHeader(HEADER);
+//        if (StringUtils.hasText(accessToken) && accessToken.startsWith(TOKEN_PREFIX)) {
+//            return accessToken.substring(TOKEN_PREFIX.length());
+//        }
+//        throw new UnauthorizedException(INVALID_ACCESS_TOKEN);
+//    }
+//}
+//
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
     private static final String HEADER = "Authorization";
@@ -27,13 +60,19 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = getAccessTokenFromRequest(request);
-        provider.validateAccessToken(accessToken); // 예외 발생 가능
-        Long userId = provider.getSubject(accessToken);
+        if (accessToken != null) {
+            try {
+                provider.validateAccessToken(accessToken);
+                Long userId = provider.getSubject(accessToken);
 
-        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, null);
-        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, null);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                SecurityContextHolder.clearContext(); // 토큰 검증 실패 시
+                throw new UnauthorizedException(INVALID_ACCESS_TOKEN_VALUE);
+            }
+        }
         filterChain.doFilter(request, response);
     }
 
@@ -42,6 +81,8 @@ public class JwtFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(accessToken) && accessToken.startsWith(TOKEN_PREFIX)) {
             return accessToken.substring(TOKEN_PREFIX.length());
         }
-        throw new UnauthorizedException(INVALID_ACCESS_TOKEN);
+        return null; // 토큰이 없거나 형식이 잘못된 경우 null을 반환
     }
 }
+
+


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 토큰을 넣으면 로그인 유저, 토큰을 넣지 않으면 비로그인 유저 -> 이를 통해 isAuthor 필드의 값이 달라짐
- SecurityConfig에 해당 로직이 필요한 2개의 api(게시물 단건 조회, 댓글 전체 조회)만 .permitAll()을 하여 토큰이 필요없는 다른 api와 분리하여 처리
- JwtFilter에서 토큰이 있으면 처리하고 없으면 null

---

### ✏️ 관련 이슈(선택 사항)
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #91 

---

### 코드 리뷰 받고 싶은 부분



---




