### PR TITLE
[hotfix] #118 댓글목록 조회 시 권한 필드 위치 이동 

### DIFF
--- a/src/main/java/ussum/homepage/application/comment/service/PostCommentManageService.java
+++ b/src/main/java/ussum/homepage/application/comment/service/PostCommentManageService.java
@@ -9,6 +9,8 @@ import ussum.homepage.application.post.service.dto.request.PostUserRequest;
 import ussum.homepage.domain.comment.PostComment;
 import ussum.homepage.domain.comment.service.PostCommentFormatter;
 import ussum.homepage.domain.comment.service.PostCommentReader;
+import ussum.homepage.domain.post.Post;
+import ussum.homepage.domain.post.service.PostReader;
 import ussum.homepage.domain.reaction.service.PostCommentReactionManager;
 import ussum.homepage.domain.reaction.service.PostReplyCommentReactionManager;
 

--- a/src/main/java/ussum/homepage/application/comment/service/dto/response/CommentListResponse.java
+++ b/src/main/java/ussum/homepage/application/comment/service/dto/response/CommentListResponse.java
@@ -4,18 +4,23 @@ import java.util.List;
 
 public record CommentListResponse(
         List<PostCommentResponse> postComments,
-        Integer total
+        Integer total,
+        List<String> allowedAuthorities
 ) {
     public static CommentListResponse of(List<PostCommentResponse> postCommentResponses, Integer total) {
-        return new CommentListResponse(postCommentResponses, total);
+        return new CommentListResponse(postCommentResponses, total, List.of());
     }
 
-    public void validAuthority(List<String> canAuthorityList) {
-        postComments.forEach(postComment -> {
-            postComment.canAuthority(canAuthorityList);
-            postComment.getPostReplyComments().stream().forEach(
-                    postReplyComment -> postReplyComment.canAuthority(canAuthorityList)
-            );
-        });
+//    public void validAuthority(List<String> canAuthorityList) {
+//        postComments.forEach(postComment -> {
+//            postComment.canAuthority(canAuthorityList);
+//            postComment.getPostReplyComments().stream().forEach(
+//                    postReplyComment -> postReplyComment.canAuthority(canAuthorityList)
+//            );
+//        });
+//    }
+
+    public CommentListResponse validAuthorities(List<String> allowedAuthorities) {
+        return new CommentListResponse(this.postComments, this.total, allowedAuthorities);
     }
 }

--- a/src/main/java/ussum/homepage/application/comment/service/dto/response/PostCommentResponse.java
+++ b/src/main/java/ussum/homepage/application/comment/service/dto/response/PostCommentResponse.java
@@ -21,10 +21,10 @@ public class PostCommentResponse {
     public Boolean isLiked;
     public Boolean isDeleted;
     public List<PostReplyCommentResponse> postReplyComments;
-    public List<String> canAuthority;
+//    public List<String> canAuthority;
 
     @Builder
-    public PostCommentResponse(Long id, String authorName, String studentId, String content, String commentType, String createdAt, String lastEditedAt, Integer likeCount, Boolean isAuthor, Boolean isLiked, Boolean isDeleted, List<PostReplyCommentResponse> postReplyComments, List<String> canAuthority) {
+    public PostCommentResponse(Long id, String authorName, String studentId, String content, String commentType, String createdAt, String lastEditedAt, Integer likeCount, Boolean isAuthor, Boolean isLiked, Boolean isDeleted, List<PostReplyCommentResponse> postReplyComments/*, List<String> canAuthority*/) {
         this.id = id;
         this.authorName = authorName;
         this.studentId = studentId;
@@ -37,7 +37,7 @@ public class PostCommentResponse {
         this.isLiked = isLiked;
         this.isDeleted = isDeleted;
         this.postReplyComments = postReplyComments;
-        this.canAuthority = canAuthority;
+//        this.canAuthority = canAuthority;
     }
 
     public static PostCommentResponse of(PostComment postComment, User user, String commentType, Integer likeCount, Boolean isAuthor, Boolean isLiked, List<PostReplyCommentResponse> postReplyComments) {
@@ -64,8 +64,8 @@ public class PostCommentResponse {
                 .build();
     }
 
-    public void canAuthority(List<String> canAuthorityList) {
-        this.canAuthority = canAuthorityList;
-    }
+//    public void canAuthority(List<String> canAuthorityList) {
+//        this.canAuthority = canAuthorityList;
+//    }
 
 }

--- a/src/main/java/ussum/homepage/application/comment/service/dto/response/PostReplyCommentResponse.java
+++ b/src/main/java/ussum/homepage/application/comment/service/dto/response/PostReplyCommentResponse.java
@@ -17,10 +17,10 @@ public class PostReplyCommentResponse {
     public Boolean isAuthor;
     public Boolean isLiked;
     public Boolean isDeleted;
-    public List<String> canAuthority;
+//    public List<String> canAuthority;
 
     @Builder
-    public PostReplyCommentResponse(Long id, String authorName, String studentId, String content, String createdAt, String lastEditedAt, Integer likeCount, Boolean isAuthor, Boolean isLiked, Boolean isDeleted, List<String> canAuthority) {
+    public PostReplyCommentResponse(Long id, String authorName, String studentId, String content, String createdAt, String lastEditedAt, Integer likeCount, Boolean isAuthor, Boolean isLiked, Boolean isDeleted/*, List<String> canAuthority*/) {
         this.id = id;
         this.authorName = authorName;
         this.studentId = studentId;
@@ -31,7 +31,7 @@ public class PostReplyCommentResponse {
         this.isAuthor = isAuthor;
         this.isLiked = isLiked;
         this.isDeleted = isDeleted;
-        this.canAuthority = canAuthority;
+//        this.canAuthority = canAuthority;
     }
 
     public static PostReplyCommentResponse of(PostReplyComment postReplyComment, User user, Integer likeCount, Boolean isAuthor, Boolean isLiked) {
@@ -55,7 +55,7 @@ public class PostReplyCommentResponse {
                 .build();
     }
 
-    public void canAuthority(List<String> canAuthorityList) {
-        this.canAuthority = canAuthorityList;
-    }
+//    public void canAuthority(List<String> canAuthorityList) {
+//        this.canAuthority = canAuthorityList;
+//    }
 }

--- a/src/main/java/ussum/homepage/application/post/service/dto/response/postDetail/PostDetailResDto.java
+++ b/src/main/java/ussum/homepage/application/post/service/dto/response/postDetail/PostDetailResDto.java
@@ -15,9 +15,9 @@ public abstract class PostDetailResDto {
     protected String createdAt;
     protected String lastEditedAt;
     protected Boolean isAuthor;
-    protected List<String> canAuthority;
+    protected List<String> allowedAuthorities;
 
-    protected PostDetailResDto(Long postId, String categoryName, String authorName, String title, String content, String createdAt, String lastEditedAt, Boolean isAuthor, List<String> canAuthority) {
+    protected PostDetailResDto(Long postId, String categoryName, String authorName, String title, String content, String createdAt, String lastEditedAt, Boolean isAuthor, List<String> allowedAuthorities) {
         this.postId = postId;
         this.categoryName = categoryName;
         this.authorName = authorName;
@@ -26,10 +26,10 @@ public abstract class PostDetailResDto {
         this.createdAt = createdAt;
         this.lastEditedAt = lastEditedAt;
         this.isAuthor = isAuthor;
-        this.canAuthority = canAuthority;
+        this.allowedAuthorities = allowedAuthorities;
     }
 
-    public void canAuthority(List<String> canAuthority) {
-        this.canAuthority = canAuthority;
+    public void canAuthority(List<String> allowedAuthorities) {
+        this.allowedAuthorities = allowedAuthorities;
     }
 }

--- a/src/main/java/ussum/homepage/domain/acl/service/post/PostAclAspect.java
+++ b/src/main/java/ussum/homepage/domain/acl/service/post/PostAclAspect.java
@@ -50,7 +50,7 @@ public class PostAclAspect {
     public Object validCommentAuthorityOfPetitionPost(ProceedingJoinPoint joinPoint, Long userId) throws Throwable {
         Object result = joinPoint.proceed();
         CommentListResponse commentListRes = (CommentListResponse) result;
-        postAclHandler.applyPermissionsToCommentList(commentListRes, userId);
+        commentListRes = postAclHandler.applyPermissionsToCommentList(commentListRes, userId);
         return commentListRes;
     }
 

--- a/src/main/java/ussum/homepage/domain/acl/service/post/PostAclHandler.java
+++ b/src/main/java/ussum/homepage/domain/acl/service/post/PostAclHandler.java
@@ -41,7 +41,7 @@ public class PostAclHandler {
         postDetailRes.validAuthority(allowedAuthorities);
     }
 
-    public void applyPermissionsToCommentList(CommentListResponse commentListRes, Long userId) {
+    public CommentListResponse applyPermissionsToCommentList(CommentListResponse commentListRes, Long userId) {
         List<String> allowedAuthorities = new ArrayList<>();
         boolean isLoggedIn = userId != null;
 
@@ -57,7 +57,7 @@ public class PostAclHandler {
             }
         }
 
-        commentListRes.validAuthority(allowedAuthorities);
+        return commentListRes.validAuthorities(allowedAuthorities);
     }
 
     private void addPermissionAuthorities(List<String> allowedAuthorities, List<String> deniedAuthorities, Long userId, String boardCode, boolean isLoggedIn) {

--- a/src/main/java/ussum/homepage/domain/comment/service/PostCommentReader.java
+++ b/src/main/java/ussum/homepage/domain/comment/service/PostCommentReader.java
@@ -7,18 +7,20 @@ import org.springframework.stereotype.Service;
 import ussum.homepage.domain.comment.PostComment;
 import ussum.homepage.domain.comment.PostCommentRepository;
 import ussum.homepage.domain.comment.service.formatter.PostCommentFormatter;
+import ussum.homepage.domain.post.PostRepository;
+import ussum.homepage.domain.post.exception.PostException;
 import ussum.homepage.domain.reaction.exception.PostCommentException;
 import ussum.homepage.global.error.exception.InvalidValueException;
 
 import java.util.List;
 
-import static ussum.homepage.global.error.status.ErrorStatus.POST_COMMENT_NOT_FOUND;
-import static ussum.homepage.global.error.status.ErrorStatus._BAD_REQUEST;
+import static ussum.homepage.global.error.status.ErrorStatus.*;
 
 @Service
 @RequiredArgsConstructor
 public class PostCommentReader {
     private final PostCommentRepository postCommentRepository;
+    private final PostRepository postRepository;
 
     public Page<PostComment> getPostCommentList(Pageable pageable, Long postId){
         return postCommentRepository.findAllByPostId(pageable, postId);
@@ -37,6 +39,7 @@ public class PostCommentReader {
     }
 
     public List<PostComment> getCommentListWithPostIdAndType(Long postId, String type) {
+        postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
         List<PostComment> comments;
         switch (type) {
             case "인기순":

--- a/src/main/java/ussum/homepage/domain/post/service/PetitionPostProcessor.java
+++ b/src/main/java/ussum/homepage/domain/post/service/PetitionPostProcessor.java
@@ -26,9 +26,10 @@ public class PetitionPostProcessor {
     private final PostCommentReader postCommentReader;
     private final MemberManager memberManager;
 
-    // 매일 자정에 실행되는 스케줄러
+    // 매일 정오에 실행되는 스케줄러
 //    @Scheduled(cron = "0 0 0 * * *")
-    @Scheduled(fixedDelay = 300000)
+//    @Scheduled(fixedDelay = 300000)
+    @Scheduled(cron = "0 0 12 * * *")
     @Transactional
     public void scheduledStatusUpdate() {
         List<Post> posts = postRepository.findAllByCategory(List.of("진행중"));


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 댓글이 존재하지 않을 때 권한 필드가 들어오지 않는 문제가 생겨 댓글이 0개여도 권한 반환하게 수정
- 권한 반환 필드명 모두 allowedAuthorities으로 변경
- 게시물의 댓글 전체 조회시 존재하지 않는 게시물이여도 예외가 터지지 않은 문제 -> 예외 처리 완료

---

### ✏️ 관련 이슈(선택 사항)
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #118 

---

### 코드 리뷰 받고 싶은 부분



---




