### PR TITLE
feat: 게시글 목록 조회 시 긴급공지 우선 정렬 기능 추가

### DIFF
--- a/src/main/java/ussum/homepage/application/post/service/dto/response/postList/DataPostResponse.java
+++ b/src/main/java/ussum/homepage/application/post/service/dto/response/postList/DataPostResponse.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import ussum.homepage.application.post.service.dto.response.FileResponse;
 import ussum.homepage.domain.post.Post;
+import ussum.homepage.infra.jpa.post.entity.Status;
 
 import java.util.List;
 
@@ -26,7 +27,7 @@ public class DataPostResponse extends PostListResDto {
                 .content(content)
                 .category(post.getCategory())
                 .date(post.getCreatedAt())
-                .isNotice(post.getTitle().equals("총학생회칙"))
+                .isNotice(post.getStatus().equals(Status.EMERGENCY_NOTICE.getStringStatus()))
                 .files(files)
                 .build();
     }


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---
### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 게시글 목록 조회 시 긴급공지(EMERGENCY_NOTICE) 상태의 게시글을 최상단에 노출하도록 정렬 로직 추가
- Querydsl orderBy 절에 case when 구문을 사용하여 긴급공지와 일반 게시글을 구분하여 정렬
- 각 상태(긴급공지/일반) 내에서는 생성일자 기준 내림차순(최신순) 정렬 적용

---
### ✏️ 관련 이슈(선택 사항)
- Related to: #215  (게시판 긴급공지 우선 노출 기능 추가)

---
### 코드 리뷰 받고 싶은 부분
- Querydsl case when 구문 사용이 적절한지 검토 부탁드립니다
- 정렬 로직이 성능에 미치는 영향이 있는지 확인 부탁드립니다

---