### PR TITLE
fix: 게시글의 파일 리스트 null 처리 수정

### DIFF
--- a/src/main/java/ussum/homepage/domain/post/service/factory/postList/DataPostResponseFactory.java
+++ b/src/main/java/ussum/homepage/domain/post/service/factory/postList/DataPostResponseFactory.java
@@ -21,8 +21,15 @@ public class DataPostResponseFactory implements PostListResponseFactory {
 
     @Override
     public PostListResDto createDataResponse(Post post, List<PostFile> postFiles) {
-        List<FileResponse> fileResponses = postFiles.stream().map(postFile -> FileResponse.of(postFile)).toList();
-        String content = postFiles.get(0).getFileCategory();
+        List<FileResponse> fileResponses = postFiles.stream()
+                .map(FileResponse::of)
+                .toList();
+
+        String content = postFiles.stream()
+                .findFirst()
+                .map(PostFile::getFileCategory)
+                .orElse(null); // 파일이 없는 경우 null로 설정
+
         return DataPostResponse.of(post, fileResponses, content);
     }
 }


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?
- [x] 버그 수정

---
### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- 파일이 없는 게시글도 목록에 포함되도록 수정
- 파일이 없는 경우 fileResponses는 빈 리스트로 반환
- 파일이 없는 경우 content는 null로 설정하도록 변경

---
### ✏️ 관련 이슈

---
### 코드 리뷰 받고 싶은 부분
- 파일이 없는 경우 content를 null로 설정하는 것이 적절한지 검토 필요
- DataPostResponse.of() 메서드에서 null content 처리가 적절히 되고 있는지 확인 필요

---
