### PR TITLE
[feat] 회원가입 사용자 수 관련 Custom Metric 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// MacOS netty resolver
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/ussum/homepage/application/user/service/UserMetricService.java
+++ b/src/main/java/ussum/homepage/application/user/service/UserMetricService.java
@@ -1,0 +1,78 @@
+package ussum.homepage.application.user.service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import ussum.homepage.domain.user.UserCountRepository;
+
+@Service
+public class UserMetricService {
+
+    private final Counter userSignupTotal;   // 전체 가입자 수
+    private final AtomicLong todayUsers;  // 오늘 가입자 수
+    private final AtomicLong lastMonthUsers;  // 최근 1개월 가입자 수
+    private final AtomicLong lastYearUsers;   // 최근 1년 가입자 수
+
+    private final UserCountRepository userCountRepository;
+
+    @Autowired
+    public UserMetricService(MeterRegistry meterRegistry, UserCountRepository userRepository) {
+        this.userCountRepository = userRepository;
+
+        long initialUserCount = userCountRepository.count();
+
+        this.userSignupTotal = Counter.builder("user_signup_total")
+            .description("총 가입자 수")
+            .register(meterRegistry);
+
+        // 실행 시 총 가입자 수 초기화
+        for (int i = 0; i < initialUserCount; i++) {
+            userSignupTotal.increment();
+        }
+
+        this.todayUsers = new AtomicLong(0);
+        this.lastMonthUsers = new AtomicLong(0);
+        this.lastYearUsers = new AtomicLong(0);
+
+        // Gauge 등록 (실시간 값 반영)
+        Gauge.builder("user_signup_today", todayUsers, AtomicLong::get)
+            .description("오늘 가입 한 사용자 수")
+            .register(meterRegistry);
+
+        Gauge.builder("user_signup_last_month", lastMonthUsers, AtomicLong::get)
+            .description("최근 한 달 가입 한 사용자 수")
+            .register(meterRegistry);
+
+        Gauge.builder("user_signup_last_year", lastYearUsers, AtomicLong::get)
+            .description("최근 1년 간 가입 한 사용자 수")
+            .register(meterRegistry);
+
+        updateSignupMetrics(); // 서버 시작 시 초기값 설정
+    }
+
+    // 회원가입 시 카운트 증가
+    public void incrementUserSignup() {
+        userSignupTotal.increment();
+        todayUsers.incrementAndGet();
+        lastMonthUsers.incrementAndGet();
+        lastYearUsers.incrementAndGet();
+    }
+
+    // 5분마다 DB 기간별 가입자 수 갱신
+    @Scheduled(fixedRate = 300000) // 5분마다 실행
+    public void updateSignupMetrics() {
+        LocalDate today = LocalDate.now();
+        LocalDate oneMonthAgo = today.minusMonths(1);
+        LocalDate oneYearAgo = today.minusYears(1);
+
+        todayUsers.set(userCountRepository.countByDate(today.atStartOfDay()));
+        lastMonthUsers.set(userCountRepository.countByDateAfter(oneMonthAgo.atStartOfDay()));
+        lastYearUsers.set(userCountRepository.countByDateAfter(oneYearAgo.atStartOfDay()));
+    }
+
+}

--- a/src/main/java/ussum/homepage/domain/user/UserCountRepository.java
+++ b/src/main/java/ussum/homepage/domain/user/UserCountRepository.java
@@ -1,0 +1,13 @@
+package ussum.homepage.domain.user;
+
+
+import java.time.LocalDateTime;
+
+public interface UserCountRepository {
+
+    Long count();
+
+    Long countByDate(LocalDateTime date);
+
+    Long countByDateAfter(LocalDateTime date);
+}

--- a/src/main/java/ussum/homepage/infra/jpa/user/UserCountRepositoryImpl.java
+++ b/src/main/java/ussum/homepage/infra/jpa/user/UserCountRepositoryImpl.java
@@ -1,0 +1,29 @@
+package ussum.homepage.infra.jpa.user;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ussum.homepage.domain.user.UserCountRepository;
+import ussum.homepage.infra.jpa.user.repository.UserCountJpaRepository;
+
+@RequiredArgsConstructor
+@Repository
+public class UserCountRepositoryImpl implements UserCountRepository {
+
+    private final UserCountJpaRepository userCountJpaRepository;
+
+    @Override
+    public Long count() {
+        return userCountJpaRepository.count();
+    }
+
+    @Override
+    public Long countByDate(LocalDateTime date) {
+        return userCountJpaRepository.countByCreatedAt(date);
+    }
+
+    @Override
+    public Long countByDateAfter(LocalDateTime date) {
+        return userCountJpaRepository.countByCreatedAtAfter(date);
+    }
+}

--- a/src/main/java/ussum/homepage/infra/jpa/user/repository/UserCountJpaRepository.java
+++ b/src/main/java/ussum/homepage/infra/jpa/user/repository/UserCountJpaRepository.java
@@ -1,0 +1,12 @@
+package ussum.homepage.infra.jpa.user.repository;
+
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import ussum.homepage.infra.jpa.user.entity.UserEntity;
+
+public interface UserCountJpaRepository extends JpaRepository<UserEntity, Long> {
+
+    Long countByCreatedAt(LocalDateTime createdAt);
+
+    Long countByCreatedAtAfter(LocalDateTime date);
+}


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용

- 유저 수 관련 metric 구현(Spring micrometer 활용)
- 오늘, 최근 1달, 최근 1년 가입한 유저 수에 대한 지표
- 실행 후 /actuator/prometheus 엔드포인트에서 확인 가능

![image](https://github.com/user-attachments/assets/06426586-f266-4201-b921-2babdde9b079)


---

### ✏️ 관련 이슈(선택 사항)

Resolves #254 

---

### 코드 리뷰 받고 싶은 부분

- UserReposiory 기존에 있는데 UserCountRepository를 따로 만들었슴다.
    - 회원가입 한 사용자 수 관련된 기능에만 쓰이는 쿼리라 분리
    - SRP 준수, 확장성 고려(기간 선택 관련해서 요청사항 바뀔수도 있어서)
    - 다른 의견 있으면 고
- 지표 최신화를 스케줄러로 5분마다 하는데 DB에 부하 안 가는 적정선이라 생각해서 적용했는데 다른 의견 있는 지
- 메인에 머지된 이후에는 Grafana로 시각화 할 예정
- 궁금한 거, 이상한 거 모두 다!

---




